### PR TITLE
header better_wellspring in flags

### DIFF
--- a/wotw_seedgen/headers/better_wellspring.wotwrh
+++ b/wotw_seedgen/headers/better_wellspring.wotwrh
@@ -2,5 +2,6 @@
 /// Better Wellspring
 ///
 /// Opens the top door of Wellspring
+Flags: Better Wellspring
 
 3|0|8|37858|31962|bool|true 


### PR DESCRIPTION
display the header better_wellspring in the flags because everybody always asks if it has been added to the seed