### PR TITLE
Validate Glades Town, Ruins and Lower Reach

### DIFF
--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -13162,8 +13162,8 @@ anchor UpperWastes.MissilePuzzleLeft at 1937, -3794:  # Immediately to the right
       DoubleJump, TripleJump, Sword  # tjump->pogo->tjump->upslash
       Burrow, Bash
       Burrow, DoubleJump, TripleJump, Hammer OR Spear=1
-      Burrow, DoubleJump, Sword  # pogo the torpedo
     unsafe:
+      Burrow, DoubleJump, Sword  # pogo the torpedo
       SentryJump=1
       Bash, DoubleJump, TripleJump  # Lure the miner on higher ground to the left
   pickup UpperWastes.MissileSpawnEX:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -3744,7 +3744,7 @@ anchor GladesTown.MotayHut at -182, -4589:  # Inside the house hovering above Mo
     unsafe, GladesTown.BuildHuts:
       GrenadeJump, DoubleJump OR Dash  # Midair Grenade Jump with auto-cancel  # dash is much harder
       SwordSJump=1, Dash
-      TuleyShop.Lightcatchers, Bash, Sword OR Hammer
+      TuleyShop.Lightcatchers, Bash, Glide OR Sword OR Hammer
 
 anchor GladesTown.UpperWest at -357, -4126:  # Where Mokk lives
   refill Checkpoint:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -8030,9 +8030,9 @@ anchor LowerReach.IceCavern at -85, -3966:  # On the snaptrap facing upwards at 
       LowerReach.FreezeEastFurnace, HammerSJump=2
     kii:
       Bash, Grenade=1, DoubleJump OR Dash OR Sword OR Hammer OR Glide OR Shuriken=1 OR Flash=1 OR Sentry=1
-      DoubleJump, Hammer OR Sentry=2
-      DoubleJump, Damage=20, Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1
-      Dash, Sword OR Hammer OR Sentry=2
+      DoubleJump, Sword OR Hammer OR Sentry=2
+      DoubleJump, Damage=20, Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1 OR Spear=1
+      Dash, Sword OR Hammer OR Sentry=3
       LowerReach.ThawEastFurnace, DoubleJump, Shuriken=1
       LowerReach.ThawEastFurnace, DoubleJump, Blaze=1, Damage=20
       LowerReach.ThawEastFurnace, Dash, Glide OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=20
@@ -8042,7 +8042,7 @@ anchor LowerReach.IceCavern at -85, -3966:  # On the snaptrap facing upwards at 
 
 anchor LowerReach.HalfwayIceCavern at -44, -3955:  # On the snaptrap halfway through the spiky ice cavern
 # Going through that ice cavern in order to activate LowerReach.EastDoorLantern or going to LowerReach.SwimmingPool is horrible to find paths for, especially when using sjumps/bashnades
-# That anchor is just so pathfinder have an easier time patfinding the horrible paths through that icy cavern.
+# That anchor is just so pathfinder have an easier time pathfinding the horrible paths through that icy cavern.
 
   state LowerReach.EastDoorLantern:
     moki:
@@ -8066,7 +8066,9 @@ anchor LowerReach.HalfwayIceCavern at -44, -3955:  # On the snaptrap halfway thr
       Glide, DoubleJump OR Dash
       Launch
     gorlek: Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Damage=20
-    kii: Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1
+    kii:
+      Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1
+      Bash, Grenade=1
   conn LowerReach.IceCavern:
     moki:
       Launch
@@ -8079,7 +8081,7 @@ anchor LowerReach.HalfwayIceCavern at -44, -3955:  # On the snaptrap halfway thr
     kii:
       Hammer OR Damage=20
       Bash, Grenade=1
-      Glide, Dash OR Sword
+      Glide, Dash OR Sword OR Shuriken=1 OR Spear=1 OR Flash=1 OR Sentry=1
       LowerReach.ThawEastFurnace, Glide OR Dash OR Sword OR Shuriken=1 OR Blaze=3 OR Sentry=2
     unsafe:
       Sword OR GlideJump
@@ -8107,7 +8109,7 @@ anchor LowerReach.SwimmingPool at -44, -4001:  # At the platform in the freezabl
       Bash, Grenade=1, Damage=20, WaterDash OR DoubleJump OR Dash OR Sword
       Bash, Grenade=1, Sword, DoubleJump OR Dash  # pogo the worm
       Bash, Grenade=1, DoubleJump, Dash, TripleJump OR Glide OR Hammer OR Sentry=2
-      Bash, Grenade=2, Dash OR Glide OR DoubleJump OR Sword OR Shuriken=1 OR Sentry=2 OR Damage=20
+      Bash, Grenade=2, Dash OR Glide OR DoubleJump OR Sword OR Sentry=2 OR Damage=20
       LowerReach.ThawEastFurnace, Bash, Water  # bash the fish under the door
       LowerReach.ThawEastFurnace, Bash, WaterDash, Damage=20, Damage=40
       LowerReach.ThawEastFurnace, WaterDash, Water, Hammer OR Spear=1  # Wall jump from the right wall
@@ -8115,6 +8117,7 @@ anchor LowerReach.SwimmingPool at -44, -4001:  # At the platform in the freezabl
       LowerReach.ThawEastFurnace, DoubleJump, TripleJump, Hammer, Water OR Dash OR Glide OR Sword OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20  # tjump+ hammer upslash from the closed snaptrap to walljump on the left wall
       LowerReach.ThawEastFurnace, DoubleJump, TripleJump, Spear=1, Water OR Dash OR Glide OR Sword OR Sentry=3 OR Damage=20  # tjump+spear from the closed snaptrap to walljump on the left wall
     unsafe, LowerReach.EastDoorLantern:
+      Bash, Grenade=2, Shuriken=1
       SwordSJump=1, DoubleJump, TripleJump OR Dash OR Glide  # double jump from the platform, refill dash/jumps by slashing the energy cristal then sjump on the plant
       SwordSJump=2, DoubleJump OR Glide OR Dash
       HammerJump
@@ -8123,15 +8126,16 @@ anchor LowerReach.SwimmingPool at -44, -4001:  # At the platform in the freezabl
       Bash, Grenade=1
       Launch
     gorlek:
-      DoubleJump, TripleJump  # Climb the right wall then jump to the left wall before double jumping again to the platform
+      DoubleJump, TripleJump  # Climb the left wall then jump to the right wall before double jumping again to the platform
       SwordSJump=1
       HammerSJump=1, Dash OR DoubleJump OR LowerReach.FreezeEastFurnace
       LowerReach.ThawEastFurnace, WaterDash, DoubleJump, Water, Sword OR Hammer
       LowerReach.ThawEastFurnace, WaterDash, DoubleJump, Damage=20, Sword OR Hammer
     kii:
-      DoubleJump  # Precise wall jump on the right wall then wjump on the left wall
-      LowerReach.ThawEastFurnace, Bash, Water OR Damage=100  # Bash the fish
+      DoubleJump  # Precise wall jump on the left wall then wjump on the right wall
       LowerReach.ThawEastFurnace, Bash, WaterDash, Water OR Damage=40
+      LowerReach.ThawEastFurnace, Bash, Water  # Bash the fish
+    unsafe: LowerReach.ThawEastFurnace, Bash, Damage=100  # Bash the fish
   conn LowerReach.HalfwayIceCavern:
     kii:
       Bash, Grenade=1, DoubleJump, TripleJump
@@ -8205,12 +8209,12 @@ anchor LowerReach.WindSpinners at 73,-3929:  # midway through the wind column ab
       Glide, DoubleJump, TripleJump OR Dash
       Launch, DoubleJump, TripleJump OR Dash OR Damage=20  # Pass under the first spinner to reach the right wall, climb it and launch to the energy cristal
     kii:
-      Launch, Dash OR Sword OR Hammer OR Damage=20  # Pass under the first spinner and launch to the wall above it
-      Glide, DoubleJump, Hammer OR Damage=20
+      Launch, Dash OR Sword OR Hammer OR Shuriken=1 OR Damage=20  # Pass under the first spinner and launch to the wall above it
+      Glide, DoubleJump OR Hammer OR Damage=20
       DoubleJump, TripleJump, Damage=60  # 2 dboosts to reach the right wall, climb it, pass between the two spinners to reach the left wall, climb it and take a third dboost
-      DoubleJump, TripleJump, Damage=40, Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # pass under the 1st spinner by using tjump, dboost, tjump again and use your other mobility option to reach the right wall, climb it, pass between the two spinners to reach the left wall, climb it and take a third dboost
+      DoubleJump, TripleJump, Damage=40, Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # pass under the 1st spinner by using tjump, dboost, tjump again and use your other mobility option to reach the right wall, climb it, pass between the two spinners to reach the left wall, climb it and take a second dboost
     unsafe:
-      Glide, Dash, Hammer
+      Glide
       Launch, Spear=1 OR Shuriken=1 OR Sentry=1 OR Spear=1 OR Flash=1  # Pass under the first spinner and launch to the wall above it
       DoubleJump, TripleJump, Damage=20
       Bash, Grenade=1, DoubleJump, TripleJump  # Precise grenade throw above the first spinner, pass under the spinner to catch the grenade and bash glide to the right wall

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -7157,9 +7157,10 @@ anchor LowerReach.Entry at -390, -4025:  # Behind Baur
       Bash, Glide, Damage=20
       SentryJump=1, DoubleJump OR Bash
     kii:
-      Bash, Damage=20, Sword OR Hammer OR Shuriken=2 OR Sentry=2 OR Flash=2
+      Bash, Damage=20, Hammer OR Sentry=3
     unsafe:
       SentryJump=1
+      #Bash, Damage=20, Sword OR Shuriken=2 OR Sentry=2 OR Flash=2
       Bash  # can be done damageless, but damage is likely. Keep jumping at the right wall until you go over it and bash the first latern at just the right angle to reach the second
       DoubleJump, TripleJump, Sentry=3, Damage=20  # https://youtu.be/EhC4SRe4UA0
       DoubleJump, TripleJump, Sword
@@ -7255,14 +7256,15 @@ anchor LowerReach.AboveEntry at -401, -4000:  # On the platform above Baur insid
       DoubleJump, Sword OR Hammer OR Sentry=2 OR Damage=20
       Dash, Sword OR Hammer
       Dash, Damage=20, Shuriken=1 OR Sentry=1 OR Flash=1 OR Blaze=1 OR Spear=1
-      Glide, Hammer OR Damage=20
+      Glide, Hammer OR Spear=1 OR Damage=20
       Sword, Shuriken=1 OR Sentry=2 OR Damage=20
-      Hammer, Damage=20, Shuriken=1 OR Sentry=1
+      Hammer, Damage=20, Shuriken=1
     unsafe, LowerReach.Lever:
       Bash, Sentry=1 OR Flash=1
-      Hammer, Damage=20, Spear=1 OR Blaze=1 OR Flash=1 OR Sentry=1
-      Glide, Spear=1 OR Sentry=1 OR Shuriken=1 OR Flash=1
-      Dash, Shuriken=1 OR Sentry=2  # Dash on the small wall from the branch where the lantern is attached, dash again then stall with sentry/shuriken
+      #Hammer, Damage=20, Spear=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Hammer, Damage=20
+      Glide, Sword OR Sentry=1 OR Shuriken=1 OR Flash=1
+      Dash, Shuriken=1 OR Sentry=2 OR Damage=20 # Dash on the small wall from the branch where the lantern is attached, dash again then stall with sentry/shuriken
   conn LowerReach.Entry: free
 
 anchor LowerReach.Icefall at -448, -3999:  # Where you drop the rock on Baur's nose
@@ -7336,7 +7338,7 @@ anchor LowerReach.Icefall at -448, -3999:  # Where you drop the rock on Baur's n
     kii, LowerReach.LeftFurnace:
       DoubleJump, Grapple
       DoubleJump, TripleJump, Dash OR Shuriken=1 OR Sentry=2
-      DoubleJump, TripleJump, Glide, Sentry=1 OR Flash=1 OR Spear=1
+      DoubleJump, TripleJump, Glide, Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
       DoubleJump, TripleJump, Combat=Nest, Hammer
       DoubleJump, Combat=Nest, Dash, Hammer
       DoubleJump, Sword, TripleJump OR Dash  # Pogo a fish or use the skeetos
@@ -7387,8 +7389,8 @@ anchor LowerReach.CentralEnemyPaths at -335, -4009:  # Enemy path counterpart fo
     kii:
       Bash, Hammer OR Spear=1
       Sword, DoubleJump, TripleJump, Spear=1
-      Sword, DoubleJump, Hammer
       LowerReach.ThawCentralFurnace, Bash, DoubleJump OR Dash OR Glide OR Sword OR Hammer OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Blaze=1 OR Spear=1
+    unsafe: Sword, DoubleJump, Hammer
   conn LowerReach.Entry:
     unsafe: LowerReach.Lever, Bash  # bash the slime near the spikes then bash glide to the lantern
 
@@ -7406,7 +7408,7 @@ anchor LowerReach.Central at -335, -4009:  # After the lever door
       LowerReach.Lever, DoubleJump, TripleJump
     kii:
       LowerReach.Lever, DoubleJump, Sword OR Hammer OR Spear=1
-      LowerReach.ThawCentralFurnace, DoubleJump, Glide, Hammer, Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
+      LowerReach.ThawCentralFurnace, DoubleJump, Glide, Hammer
       LowerReach.ThawCentralFurnace, DoubleJump, Glide, Spear=1, Shuriken=1 OR Sentry=1 OR Flash=1
       LowerReach.ThawCentralFurnace, DoubleJump, Glide, Spear=2
       LowerReach.ThawCentralFurnace, DoubleJump, Sentry=2, Hammer OR Spear=1
@@ -7445,11 +7447,12 @@ anchor LowerReach.Central at -335, -4009:  # After the lever door
       SwordSJump=2, Spear=1
       HammerSJump=3
     kii:
-      LowerReach.Lever, Hammer, DoubleJump, Glide OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
+      LowerReach.Lever, Hammer, DoubleJump, Glide OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1 OR Damage=20
       LowerReach.Lever, Spear=1, DoubleJump, Dash
       LowerReach.ThawCentralFurnace, DoubleJump, Glide, Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
       LowerReach.ThawCentralFurnace, DoubleJump, Sentry=5
-      LowerReach.ThawCentralFurnace, LowerReach.Lever, DoubleJump, Spear=2  # from LowerReach.AboveDoorEX
+      LowerReach.ThawCentralFurnace, DoubleJump, Sentry=2, Damage=20
+      LowerReach.ThawCentralFurnace, LowerReach.Lever, DoubleJump, Spear=2, Damage=20  # from LowerReach.AboveDoorEX
     unsafe:
       LowerReach.Lever, DoubleJump, Sword, Spear=1  # Pogo the mortar projectile once it hit the snaptrap
       Grenade=2, Hammer OR Spear=1  # GrenadeJump=2, Hammer OR Spear=1
@@ -7460,7 +7463,7 @@ anchor LowerReach.Central at -335, -4009:  # After the lever door
   conn LowerReach.SecondSoup: free
   conn LowerReach.BelowLupo:
     kii:
-      DoubleJump OR Dash OR Glide OR Sword OR Hammer OR Sentry=2
+      DoubleJump OR Dash OR Glide OR Sword OR Hammer OR Sentry=2 OR Blaze=3
       Damage=10, Shuriken=1 OR Sentry=1 OR Flash=1 OR Blaze=2
   conn LowerReach.OutsideTPRoom:
     moki:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -13553,7 +13553,9 @@ anchor WindtornRuins.LowerRuins at 1969, -4024:  # At the ancient map pedestal
       SentryJump=1
     kii, WindtornRuins.HeartBarrier, WindtornRuins.Seir:
       DoubleJump, Burrow OR Hammer OR Spear=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Blaze=1
-      Dash, Glide
+      Dash, Glide OR Sword OR Hammer OR Spear=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Blaze=1
+    unsafe, WindtornRuins.HeartBarrier, WindtornRuins.Seir:
+      Dash OR DoubleJump
   conn LowerWastes.MinesEntranceEnemyPaths:
     moki: Burrow, BreakWall=20
 

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -13423,7 +13423,7 @@ anchor WindtornRuins.BrokenMural at 2108, -3959:  # At the broken mural above th
       WindtornRuins.HeartBarrier, DoubleJump, TripleJump OR Sword OR Hammer
     kii:
       WindtornRuins.HeartBarrier, Hammer OR Sword OR Sentry=2
-      Burrow, Hammer OR Sword
+      Burrow, Hammer
       Burrow, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # burrow the crumbing platform
     unsafe: Burrow  # at the pilar, hold up+right and burrow through the crumbing platform
 
@@ -13436,7 +13436,7 @@ anchor WindtornRuins.FallenPillar at 2090, -4012:  # After dropping down from th
       Burrow, Bash, Grenade=1
     gorlek: Burrow, BreakWall=16
     unsafe: ShurikenBreak=16 OR SentryBreak=16
-  
+
   conn WindtornRuins.RuinsTP:  # this accounts for both situations of having broken the heart or not
     moki:
       Burrow, DoubleJump, Dash OR Glide
@@ -13492,7 +13492,7 @@ anchor WindtornRuins.RuinsTP at 2130, -3984:  # Windtorn Ruins teleporter.
       WindtornRuins.HeartBarrier, Dash, Hammer OR Sentry=2
       WindtornRuins.HeartBarrier, Sword, Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1 OR Hammer
       WindtornRuins.HeartBarrier, Hammer, Sentry=2
-      Burrow, Sword OR Sentry=3  # jump on the left side of the crumbing platform and burrow it from underneath. You can slow yourself down with slashes
+      Burrow, Sword  # jump on the left side of the crumbing platform and burrow it from underneath. You can slow yourself down with slashes
       Burrow, DoubleJump, TripleJump OR Dash OR Hammer OR Blaze=3 OR Sentry=2
       Burrow, Dash, Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # burrow the crumbing platform from the left side
       Burrow, Hammer, Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1    
@@ -13500,6 +13500,7 @@ anchor WindtornRuins.RuinsTP at 2130, -3984:  # Windtorn Ruins teleporter.
       Burrow OR WindtornRuins.HeartBarrier:
         Sword, Spear=1 OR Blaze=1
       Burrow, DoubleJump  # right side of the crumbing platform, touch it just before burrowing into it so you get a lot more speed
+      Burrow, Sentry=3
       Burrow, Hammer, Spear=1 OR Blaze=1
 
 anchor WindtornRuins.Escape at 2021, -4026:
@@ -13525,8 +13526,9 @@ anchor WindtornRuins.Escape at 2021, -4026:
       Burrow, Grapple, Sentry=5 OR Shuriken=5  # Same path, different energy weapon
       Burrow, Grapple, Damage=30, Sentry=3 OR Shuriken=3  # Sentry=5 / Shuriken=5 path but saving 2 uses by dboosting in the section where you fall down
       Burrow, Grapple, Damage=70, Sentry=2 OR Shuriken=2  # Sentry=5 / Shuriken=5 path but saving the first 3 uses by dboosting
-      Burrow, Dash, DoubleJump OR Hammer  # djump/upslash at the end of the second sandball+grapple section before dashing in order to avoid the spikes 
-    unsafe, WindtornRuins.HeartBarrier: 
+      Burrow, Dash, DoubleJump  # djump at the end of the second sandball+grapple section before dashing in order to avoid the spikes
+    unsafe, WindtornRuins.HeartBarrier:
+      Burrow, Dash, Hammer  # upslash at the end of the second sandball+grapple section before dashing in order to avoid the spikes
       Burrow, Grapple, Damage=10  # You are allowed to hate me if this is forced progression https://youtu.be/H3UIH4FyU4Q
       Burrow, Grapple, Blaze=5 OR Flash=5
       Burrow, Dash, Damage=40, Sentry=1 OR Flash=1
@@ -13550,7 +13552,7 @@ anchor WindtornRuins.LowerRuins at 1969, -4024:  # At the ancient map pedestal
       DoubleJump, TripleJump OR Sword
       SentryJump=1
     kii, WindtornRuins.HeartBarrier, WindtornRuins.Seir:
-      Burrow, DoubleJump, Dash
+      DoubleJump, Burrow OR Hammer OR Spear=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Blaze=1
       Dash, Glide
   conn LowerWastes.MinesEntranceEnemyPaths:
     moki: Burrow, BreakWall=20

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -8210,11 +8210,11 @@ anchor LowerReach.WindSpinners at 73,-3929:  # midway through the wind column ab
       Launch, DoubleJump, TripleJump OR Dash OR Damage=20  # Pass under the first spinner to reach the right wall, climb it and launch to the energy cristal
     kii:
       Launch, Dash OR Sword OR Hammer OR Shuriken=1 OR Damage=20  # Pass under the first spinner and launch to the wall above it
-      Glide, DoubleJump OR Hammer OR Damage=20
+      Glide, DoubleJump, Hammer OR Damage=20
       DoubleJump, TripleJump, Damage=60  # 2 dboosts to reach the right wall, climb it, pass between the two spinners to reach the left wall, climb it and take a third dboost
       DoubleJump, TripleJump, Damage=40, Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # pass under the 1st spinner by using tjump, dboost, tjump again and use your other mobility option to reach the right wall, climb it, pass between the two spinners to reach the left wall, climb it and take a second dboost
     unsafe:
-      Glide
+      Glide, Dash, Hammer
       Launch, Spear=1 OR Shuriken=1 OR Sentry=1 OR Spear=1 OR Flash=1  # Pass under the first spinner and launch to the wall above it
       DoubleJump, TripleJump, Damage=20
       Bash, Grenade=1, DoubleJump, TripleJump  # Precise grenade throw above the first spinner, pass under the spinner to catch the grenade and bash glide to the right wall
@@ -8407,7 +8407,8 @@ anchor LowerReach.VeralHome at -140, -4096:  # At the soup
     unsafe:
       GrenadeJump, DoubleJump OR Dash OR Sword OR Hammer
       Dash, Glide, Sword  # Needs a ramp on the left side corner of the platform near the cauldron
-      DoubleJump, Glide OR Sword OR Hammer # Jump on the floating platform next to the soup then wall jump from the wall above it
+      #DoubleJump, Glide OR Sword OR Hammer # Jump on the floating platform next to the soup then wall jump from the wall above it
+      DoubleJump  # Go on the wall above the Gorlek
 
 anchor LowerReach.TownEntry at -35, -4077:  # Where the wind starts
   conn LowerReach.VeralHome: free
@@ -8419,11 +8420,14 @@ anchor LowerReach.TownEntry at -35, -4077:  # Where the wind starts
       Launch, Bash, Grenade=1
     kii:
       Launch, Damage=40
-      Launch, Damage=20, Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Launch, Damage=20, Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # Avoid the second dboost
       Bash, Grenade=1, DoubleJump, TripleJump, Dash, Hammer, Damage=20
     unsafe:
       Bash, Grenade=1, DoubleJump, TripleJump, Dash, Hammer OR Damage=20
       Bash, Grenade=1, DoubleJump, TripleJump, Spear=1, Damage=20  # extend your bash with spear
+      Bash, Grenade=1, DoubleJump, TripleJump, Damage=40
+      DoubleJump, TripleJump, Damage=80, Hammer OR Spear=1  # tjump + hammer/spear to reach the wall
+      DoubleJump, TripleJump, Dash, Damage=60, Hammer OR Spear=1  # tjump + hammer/spear to reach the wall
       Launch, DoubleJump, Dash OR TripleJump
       Launch, Damage=20  # Launch on the wall at the start of the wind cave
 
@@ -8448,26 +8452,32 @@ anchor LowerReach.TrialStart at 64, -4045:  # At trial start
       SentryJump=1, DoubleJump
       Bash, Grenade=1, DoubleJump
     kii:
-      Dash, DoubleJump, TripleJump, Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      DoubleJump, TripleJump, Hammer, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Dash, DoubleJump, TripleJump, Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # Start from the right
+      DoubleJump, TripleJump, Hammer, Spear=1  # Start from the left and reach the wall
+    unsafe:
+      Dash, DoubleJump, TripleJump  # Start from the right
+      DoubleJump, TripleJump, Hammer, Shuriken=1 OR Flash=1 OR Sentry=1  # Start from the left and reach the wall
   pickup LowerReach.UpperLeftKS:
     moki: Glide
     kii:  # TP out after taking the pickup
       Launch, DoubleJump, TripleJump, Damage=30  # dboost in the spikes+ dboost on the slime next to the keystone
       DoubleJump, TripleJump, Combat=BombSlug, Damage=80
-    unsafe: Launch, DoubleJump, TripleJump, Damage=20  # Launch against the walls. When on the wall above LowerReach.VeralHome, first use triple jump then lauch, triple jump again to take a damage boost to refresh launch then launch and triple jump again to take the pickup and tp out
+    unsafe:
+      Launch, DoubleJump, TripleJump, Damage=20  # Launch against the walls. When on the wall above LowerReach.VeralHome, first use triple jump then launch, triple jump again to take a damage boost to refresh launch then launch and triple jump again to take the pickup and tp out
+      DoubleJump, TripleJump, Combat=BombSlug, Damage=60
   pickup LowerReach.MiddleLeftKS:
     moki: Glide
     kii:  # TP out after taking the pickup
-      DoubleJump, TripleJump, Damage=60
       Launch, Damage=40
       Launch, DoubleJump, Damage=20, TripleJump OR Dash
-    unsafe: Launch, Damage=20, DoubleJump OR Dash  # Launch against the walls. When on the wall above LowerReach.VeralHome, first use djump/dash then lauch, reuse your mobility option, take a damage boost to refresh launch, take the pickup and TP out
+    unsafe:
+      Launch, Damage=20, DoubleJump OR Dash  # Launch against the walls. When on the wall above LowerReach.VeralHome, first use djump/dash then launch, reuse your mobility option, take a damage boost to refresh launch, take the pickup and TP out
+      DoubleJump, TripleJump, Damage=40
   pickup LowerReach.BottomLeftKS:
     moki: Glide
     kii:  # TP out after taking the pickup
-      Launch, DoubleJump OR Dash OR Sword OR Hammer OR Sentry=3 OR Damage=20  # sentry where the two bomb slug are, walljump launch, 2 senties
-      DoubleJump, TripleJump, Combat=BombSlug, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
+      Launch, DoubleJump OR Dash OR Sword OR Hammer OR Sentry=3 OR Damage=20  # sentry where the two bomb slug are, walljump launch, 2 sentries
+      DoubleJump, TripleJump, Damage=20, Combat=BombSlug, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
     unsafe:
       Launch, Shuriken=1 OR Flash=1 OR Sentry=1  # shuriken/flash/sentry before using launch
       DoubleJump, TripleJump, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=10  # dboost on the flying spikes, which only deal 10 damages
@@ -8476,8 +8486,9 @@ anchor LowerReach.TrialStart at 64, -4045:  # At trial start
     kii:
       Launch, Damage=40  # Pass under the two falling slimes
       Launch, Damage=20, DoubleJump OR Dash
-      Launch, DoubleJump, TripleJump
+      Launch, DoubleJump, TripleJump, Hammer OR Spear=1  # Extra ability to help reaching the pickup
     unsafe:
+      Launch, DoubleJump, TripleJump
       GrenadeJump, DoubleJump, TripleJump, Damage=20
       HammerJump, DoubleJump, TripleJump, Damage=20
       FlashSwap  # TODO: calculate blaze swaps

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -7630,7 +7630,7 @@ anchor LowerReach.BelowTokk at -296, -3944:
       Burrow, LowerReach.ThawCentralFurnace, DoubleJump, Dash OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
       Burrow, LowerReach.ThawCentralFurnace, Dash, Hammer
     unsafe:
-      Burrow, DoubleJump, Hammer  # Hammer early to avoid the fake autotarget near the wall
+      Burrow, DoubleJump, Hammer OR Spear=1  # Hammer early to avoid the fake autotarget near the wall
       Burrow, DoubleJump, Damage=20
       Burrow, LowerReach.ThawCentralFurnace, Combat=Mantis, Dash, Spear=1
 
@@ -7693,9 +7693,9 @@ anchor LowerReach.SecondSoup at -316, -4037:  # Next to the soup below the telep
       DoubleJump, TripleJump
       SentryJump=1
     kii:
-      DoubleJump, Dash OR Glide OR Sword OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Damage=10
-      Dash, Sword OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
-      Dash, Glide, Damage=10
+      Damage=10
+      DoubleJump, Dash OR Glide OR Sword OR Shuriken=1 OR Sentry=1 OR Flash=1
+      Dash, Glide OR Sword OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
     unsafe: free  # jump over the ShieldMiner from the soup
 
 anchor LowerReach.BelowLupo at -278, -4031:  # On the platform left of the central furnace
@@ -7714,7 +7714,7 @@ anchor LowerReach.BelowLupo at -278, -4031:  # On the platform left of the centr
       SentryJump=1, DoubleJump OR Dash OR Damage=20  # sjump from the frozen plant
       LowerReach.ThawCentralFurnace, Sword OR Damage=20
     kii:
-      Bash, Grenade=1, Sword OR Hammer
+      Bash, Grenade=1, Sword OR Hammer OR Shuriken=1
       LowerReach.ThawCentralFurnace, Glide OR Hammer OR Shuriken=1 OR Sentry=1 OR Flash=1
     unsafe:
       Bash, Grenade=1
@@ -7723,8 +7723,7 @@ anchor LowerReach.BelowLupo at -278, -4031:  # On the platform left of the centr
   conn LowerReach.SecondSoup:
     moki: Combat=ShieldMiner OR Bash OR Launch
     gorlek: DoubleJump OR SentryJump=1
-    kii: Dash
-    unsafe: Damage=10
+    kii: Dash OR Damage=10
   conn LowerReach.CentralFurnacePedestal:
     moki: LowerReach.ThawCentralFurnace OR DoubleJump OR Dash OR Glide
     gorlek: free
@@ -7755,7 +7754,7 @@ anchor LowerReach.CentralFurnacePedestal at -256, -4035:  # The furnace left of 
     gorlek:
       Glide OR SentryJump=1
       DoubleJump, TripleJump OR Dash
-    kii: DoubleJump OR Dash OR Damage=20
+    kii: DoubleJump OR Dash OR Damage=10
     unsafe: free
 
 anchor LowerReach.WindChannel at -223, -4043:  # At the lantern opening the wind channel
@@ -7779,8 +7778,8 @@ anchor LowerReach.WindChannel at -223, -4043:  # At the lantern opening the wind
       Launch, DoubleJump, TripleJump OR Dash OR Glide OR Sword OR Hammer OR Damage=20
       Launch, Damage=20, Dash, Glide OR Sword OR Hammer
     kii:
-      DoubleJump, TripleJump, Damage=60, Hammer
-      DoubleJump, TripleJump, Damage=60, Bash, Grenade=1
+      DoubleJump, TripleJump, Damage=60, Hammer OR Spear=1  # Condition in case the wall is broken
+      DoubleJump, TripleJump, Damage=60, Bash, Grenade=1  # Condition in case the wall is broken
       Launch, Dash OR Damage=40
       Launch, DoubleJump, Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
     unsafe:
@@ -7809,7 +7808,7 @@ anchor LowerReach.WindChannel at -223, -4043:  # At the lantern opening the wind
 
 anchor LowerReach.SoupMoki at -240, -3989:  # Below the reach teleporter, where you hand delicious marshclam soup to a moki (or alternatively extuingish his fireplace...)
   refill Energy=4:
-    moki: BreakCrystal, DoubleJump OR Dash OR Glide
+    moki: BreakCrystal, DoubleJump OR Dash OR Glide OR Launch
     gorlek:
       Sword OR Hammer
       Bash, Grenade=1
@@ -7829,7 +7828,7 @@ anchor LowerReach.SoupMoki at -240, -3989:  # Below the reach teleporter, where 
       DoubleJump, Shuriken=1 OR Sentry=1 OR Flash=1 OR Blaze=1 OR Spear=1
       Dash, Shuriken=1 OR Sentry=1 OR Flash=1 OR Blaze=1 OR Spear=1
     unsafe:
-      Sword OR Flash=1 OR Sentry=1 OR Shuriken=1
+      DoubleJump OR Dash OR Sword OR Flash=1 OR Sentry=1 OR Shuriken=1
       Bash, Grenade=1
 
   conn LowerReach.WindChannel:
@@ -7930,7 +7929,6 @@ anchor LowerReach.Snowball at -182, -3968:  # At the ledge above the snowball ic
     kii:
       SentryBurn=1, Bash, DoubleJump OR Glide OR Hammer
       SentryBurn=1, Bash, Dash, Damage=20
-    kii:
       SentryBurn=1, DoubleJump, TripleJump, Dash OR Sword OR Hammer OR Sentry=2 OR Damage=20  # Jump from the branch above the ice, triple jump to get close enough, sentry to melt the ice then return to safety
     unsafe:
       SentryBurn=1, Damage=20, SentryJump=1  # Jump in the spikes (won't damage Ori afterwards), sjump then sentry to melt the ice + sword combo to return to safety

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -3411,10 +3411,9 @@ anchor GladesTown.Teleporter at -307, -4153:  # The glades teleporter
     moki, GladesTown.ClearThorns: Water, WaterDash OR Launch
     gorlek, GladesTown.ClearThorns: Water, DoubleJump, TripleJump
     kii, GladesTown.ClearThorns:
-      Water, Bash, Grenade=1
       Water, DoubleJump, Hammer  # wjump+djump+hammer. Possible from both walls
     unsafe, GladesTown.ClearThorns:
-      Bash, Grenade=1, Water OR Damage=100
+      Bash, Grenade=1, Water OR Damage=100  # The grenade has to be launched from the very edge of the platform
       GrenadeJump, Water OR Damage=100
       DoubleJump, Water OR Damage=100
       WaterDash, Damage=40
@@ -3459,7 +3458,7 @@ anchor GladesTown.Teleporter at -307, -4153:  # The glades teleporter
       Bash, Grenade=2
       #Bash, Grenade=2, Glide OR Sword OR DoubleJump
       GrenadeJump, DoubleJump OR Dash OR Sword OR Hammer
-      SwordSJump=1  # high sjump to reach the wall on the lef t of the bridge then wall jump and upslash+downslash
+      SwordSJump=1  # high sjump to reach the wall on the left of the bridge then wall jump and upslash+downslash
       TuleyShop.StickyGrass, Grapple, DoubleJump  # ceiling jump
   conn GladesTown.AboveOpher:  # paths using the platform left above the coals may want to go to GladesTown.LeftAboveCoals first
     moki:
@@ -3471,11 +3470,12 @@ anchor GladesTown.Teleporter at -307, -4153:  # The glades teleporter
       DoubleJump, TripleJump  # still works with the second huts there
     kii:
       DoubleJump, Glide OR Dash OR Sword OR Hammer OR Sentry=2  # from where Tuley is. Building the second house makes it harder but still possible
+      Dash, Hammer  # coyote dash form where Tuley to the wall, then upslash+dash to reach the platform. Building the second house makes it way harder
     unsafe:
       Grenade=1, Sword  # Grenade Pogos. I'm pretty sure this is impossible once you build the second house but I won't remove the path because I wasn't the one writting it and it's unsafe
       GrenadeJump
       WaveDash  # wavedash from where Tuley is. If the second house is built, you have to jump out of your wavedash.
-      Dash, GlideJump OR Hammer  # coyote dash form where Tuley. Could be kii but building the second house makes it way harder
+      Dash, GlideJump  # coyote dash form where Tuley. Building the second house makes it way harder
       Dash, Burrow  # I'm pretty sure this is impossible once you build the second house but I won't remove the path because I wasn't the one writting it and it's unsafe
   conn GladesTown.LeftAboveCoals:  # check for redundancies with AboveOpher
     moki:
@@ -3545,8 +3545,8 @@ anchor GladesTown.TwillenHome at -414, -4160:  # At Twillen in Glades
       Bash, Grenade=1
       GladesTown.ClearThorns OR DoubleJump OR Launch
     gorlek: SentryJump=1
-    kii: Hammer OR Spear=1
-    unsafe: Sword OR Dash OR Damage=10 OR GlideJump OR GrenadeJump
+    kii: Sword OR Hammer OR Spear=1 OR Damage=20
+    unsafe: Dash OR Damage=10 OR GlideJump OR GrenadeJump
 
 anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twillen
   refill Checkpoint
@@ -3593,8 +3593,8 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       TuleyShop.StickyGrass:
         DoubleJump, TripleJump
         Bash, Grenade=1, Dash
-        Bash, Grenade=1, Sword, Spear=1 OR Shuriken=1
-        TuleyShop.Lightcatchers, Bash, Sword
+        Bash, Grenade=1, Sword, Spear=1 OR Shuriken=1 OR Sentry=1 OR Flash=1
+        TuleyShop.Lightcatchers, Bash, Sword, Spear=1 OR Shuriken=1 OR Sentry=1 OR Flash=1
         TuleyShop.Lightcatchers, Bash, Hammer, Flash  # Possible with other energy weapons but you need to be careful about not damaging the plant
     unsafe:
       SentryJump=2  # Midairs
@@ -3603,7 +3603,8 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
         DoubleJump, TripleJump, GlideJump
       TuleyShop.Lightcatchers, Bash, Grenade=1
       DoubleJump, TripleJump, Dash OR Glide  # using the ceiling from the left
-      TuleyShop.StickyGrass, TuleyShop.Lightcatchers, Bash, Hammer
+      TuleyShop.StickyGrass, TuleyShop.Lightcatchers, Bash, Hammer OR Sword
+      TuleyShop.StickyGrass, Bash, Grenade=1, Sword
 
   conn GladesTown.MotayHut:
     moki, GladesTown.BuildHuts:
@@ -3616,10 +3617,10 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       SentryJump=1
       DoubleJump, TripleJump OR Sword OR Hammer
     kii, GladesTown.BuildHuts:
-      DoubleJump, TripleJump OR Dash OR Glide OR Sword OR Hammer OR Shuriken=1 OR Sentry=2
-      Dash, Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      DoubleJump, Shuriken=1 OR Sentry=2
+      Dash, Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       Sword, Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Hammer, Glide, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Hammer, Glide, Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe, GladesTown.BuildHuts:
       GrenadeJump
       Bash  # slime lure
@@ -3627,6 +3628,7 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       Dash  # late coyote
       Sword  # high jump, full combo, upslash and then downslash (all while holding right)
       # Dash, Glide OR Sword OR Hammer
+      Hammer, Glide, Blaze=1 OR Spear=1
   conn WestGlades.PastTown:
     moki:
       Bash, DoubleJump OR Dash
@@ -3640,7 +3642,7 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
     kii:
       Bash, Sword OR Hammer
       Bash, Damage=10, Shuriken=2 OR Flash=2 OR Sentry=2
-      Dash, Hammer, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Dash, Hammer, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, TripleJump OR Dash
       Sword, DoubleJump, Damage=10
       Combat=2xWeakSlug, DoubleJump, Damage=20, Blaze=1 OR Damage=10
@@ -3648,6 +3650,7 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       Combat=2xWeakSlug, DoubleJump, Damage=10, Glide OR Hammer OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Combat=2xWeakSlug, DoubleJump, Glide, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
+      Bash, Damage=10, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, Damage=20
       SwordSJump=1, Damage=10
       HammerSJump=1, Damage=20
@@ -3663,9 +3666,9 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       TuleyShop.StickyGrass, Grapple, Glide
     gorlek: TuleyShop.Lightcatchers, Bash, Dash, Sword OR Hammer
     kii:
-      GladesTown.BuildHuts, Dash, Sword
-      GladesTown.BuildHuts, Dash, Glide, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
-      GladesTown.BuildHuts, Sword, Glide, Shuriken=1 OR Flash=1 OR Sentry=1
+      #GladesTown.BuildHuts, Dash, Sword  # Redundant with TwillenHome -> Teleporter
+      GladesTown.BuildHuts, Dash, Glide
+      #GladesTown.BuildHuts, Sword, Glide, Shuriken=1 OR Flash=1 OR Sentry=1  # Redundant with TwillenHome -> Teleporter
   conn GladesTown.UpperWest:  # paths that use the huts may want to go to MotayHut first; check for redundancies with Teleporter
     moki:
       TuleyShop.StickyGrass, Launch
@@ -3689,17 +3692,17 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       TuleyShop.Lightcatchers, Bash:
         Glide
         Flash=1, DoubleJump OR Dash  # Would be possible with other weapons but the second plant can be destroyed
-        TuleyShop.StickyGrass, Grapple
+        TuleyShop.StickyGrass, Grapple, Flash=1 OR Sentry=1 OR Shuriken=1
       TuleyShop.BlueMoon, Grapple
       TuleyShop.StickyGrass:
         DoubleJump, TripleJump, Glide OR Dash OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # condition for reaching the bridge
-        Grapple, DoubleJump, Dash, Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+        Grapple, DoubleJump, Dash, Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
     unsafe:
       Grenade=2, DoubleJump, Sword  # Midair Grenade Pogo
       TuleyShop.Lightcatchers, Bash  # Use the slimes to reach the plant above Motay then bash glide to the bridge
       TuleyShop.StickyGrass:
         DoubleJump, TripleJump
-        Grapple, DoubleJump, Dash, Glide OR Sword
+        Grapple, DoubleJump, Dash, Glide
 
 anchor GladesTown.MotayHut at -182, -4589:  # Inside the house hovering above Motay
   # IMPORTANT this anchor is INSIDE the hut. It may only be accessed if the player has the BuildHuts state
@@ -3718,14 +3721,15 @@ anchor GladesTown.MotayHut at -182, -4589:  # Inside the house hovering above Mo
       SentryJump=2
       TuleyShop.StickyGrass, SentryJump=1
     kii, GladesTown.BuildHuts, TuleyShop.BlueMoon, Grapple, Bash, Grenade=1:  # grapple the right plant to reach the house above
-      DoubleJump, TripleJump OR Dash OR Glide OR Sword OR Hammer OR Shuriken=2 OR Sentry=3
-      Dash, Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2
+      DoubleJump, TripleJump OR Dash OR Glide OR Sword OR Hammer OR Shuriken=1 OR Sentry=1 OR Flash=1
+      Dash, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       TuleyShop.StickyGrass, GrenadeJump  # you can Grenadejump as you exit the unbuilt house and grab the moss
       GladesTown.BuildHuts:
         GrenadeJump
         TuleyShop.BlueMoon, Grapple, DoubleJump, TripleJump
-        TuleyShop.BlueMoon, Grapple, Bash, Grenade=1, Dash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR PauseHover # grapple the right plant to reach the house above
+        TuleyShop.BlueMoon, Grapple, Bash, Grenade=1, Dash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR PauseHover  # grapple the right plant to reach the house above
+        TuleyShop.BlueMoon, Grapple, Bash, Grenade=1, DoubleJump  # grapple the right plant to reach the house above
 
   conn GladesTown.West: free
   conn GladesTown.UpperWest:
@@ -3737,7 +3741,6 @@ anchor GladesTown.MotayHut at -182, -4589:  # Inside the house hovering above Mo
       Bash, Grenade=1
       SentryJump=1, DoubleJump, TripleJump OR Dash
       TuleyShop.Lightcatchers, Bash, Dash
-    kii: GladesTown.BuildHuts, TuleyShop.Lightcatchers, Bash, Glide
     unsafe, GladesTown.BuildHuts:
       GrenadeJump, DoubleJump OR Dash  # Midair Grenade Jump with auto-cancel  # dash is much harder
       SwordSJump=1, Dash
@@ -3840,8 +3843,12 @@ anchor GladesTown.AcornMoki at -347, -4182:  # At the moki near the cave
     kii, GladesTown.CaveEntrance:
       Flash:
         DoubleJump, TripleJump
-        Damage=32, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2 #That partcular water only deals 4 damage per tic
+        Water, Shuriken=2 OR Blaze=3 OR Sentry=2
+        Water, Damage=10, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
+        Damage=32, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2  # That partcular water only deals 4 damage per tic
         WaterDash, Damage=16, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2
+        WaterDash, Damage=26, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
+        Damage=42, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
         Water, Damage=10, Damage=10
         Damage=10, Damage=42
         WaterDash, Damage=10, Damage=26
@@ -3862,7 +3869,7 @@ anchor GladesTown.AcornMoki at -347, -4182:  # At the moki near the cave
       DoubleJump, TripleJump, Grenade=1, Sword, Water OR Damage=10
   quest GladesTown.MokiAcornQuest:
     moki: GladesTown.AcornQI
-  
+
   pickup GladesTown.AboveCaveEX:
     moki:
       Launch OR DoubleJump
@@ -3902,7 +3909,7 @@ anchor GladesTown.BelowBountyShard at -247, -4121:  # Bridge bellow the bounty s
       SentryJump=1
       TuleyShop.StickyGrass, DoubleJump OR Grapple
     kii:
-      DoubleJump, Hammer OR Spear=1
+      DoubleJump, Hammer OR Spear=1 OR Sentry=1 OR Flash=1
     unsafe:
       DoubleJump
       GrenadeJump
@@ -3916,7 +3923,7 @@ anchor GladesTown.BelowBountyShard at -247, -4121:  # Bridge bellow the bounty s
     gorlek:
       DoubleJump OR Dash OR Glide  # Sword is possible but TuleyShop.Lightcatchers makes is awkward
       TuleyShop.Lightcatchers, Bash
-    kii: Sword OR Hammer OR Sentry=2
+    kii: Sword OR Hammer OR Sentry=2 OR Blaze=4
 
 anchor GladesTown.LeftAboveCoals at -239, -4136:  # On the platform hovering to the left above the coals near Opher
   pickup GladesTown.UpdraftCeilingEX:
@@ -3932,7 +3939,7 @@ anchor GladesTown.LeftAboveCoals at -239, -4136:  # On the platform hovering to 
     kii:
       Dash OR Spear=1  # coyote dash or spear under the pickup
       Bash, Grenade=1
-      TuleyShop.SpringPlants, Sentry=2
+      TuleyShop.SpringPlants, Sentry=3
     unsafe:
       Sword OR GrenadeJump OR GlideJump
       TuleyShop.SpringPlants, PauseHover
@@ -3951,6 +3958,7 @@ anchor GladesTown.LeftAboveCoals at -239, -4136:  # On the platform hovering to 
     moki: DoubleJump
     gorlek: Dash OR Glide
     kii: Sword OR Hammer OR Sentry=1 OR Shuriken=1 OR Flash=1 OR Spear=1
+    unsafe: Blaze=1
 
 anchor GladesTown.AboveOpher at -212, -4133:  # On the platform above Opher
   refill Checkpoint:
@@ -3975,10 +3983,12 @@ anchor GladesTown.AboveOpher at -212, -4133:  # On the platform above Opher
       SwordJump OR GrenadeJump
       TuleyShop.SpringPlants, Grenade=1 OR GrenadeCancel  # increased height bounce
   conn TuleyShop:  # check for redundancies with Teleporter
-    moki:
+    moki, GladesTown.TuleySpawned:
       Glide
       GladesTown.RoofsOverHeads, Dash
-    gorlek: Dash, Sword OR Hammer
+    gorlek: GladesTown.TuleySpawned, Dash, Sword OR Hammer
+    kii: GladesTown.TuleySpawned, Blaze=2 OR Sentry=1 OR Flash=1 OR Shuriken=1
+    unsafe: GladesTown.TuleySpawned, Spear=2
     # seed paths tbd if ever necessary
 
 anchor GladesTown.PlayfulMoki at -210, -4122:  # At the Moki who would rather play
@@ -3995,6 +4005,7 @@ anchor GladesTown.PlayfulMoki at -210, -4122:  # At the Moki who would rather pl
   conn TuleyShop:  # check for redundancies with AboveOpher and Teleporter
     moki: GladesTown.TuleySpawned, Dash
     gorlek: GladesTown.TuleySpawned, Sword OR Hammer
+    kii: GladesTown.TuleySpawned, Blaze=1 OR Spear=1
     # seed paths tbd if ever necessary
 
 anchor GladesTown.LupoHouse at -207, -4161:  # At the entrance of Lupo's house
@@ -4054,6 +4065,7 @@ anchor GladesTown.HoleHut at -214, -4111:  # The ledge below Hole Hut
       TuleyShop.SpringPlants, TuleyShop.StickyGrass, Grapple, Shuriken=2 OR Flash=2 OR Sentry=2
     unsafe:
       GrenadeJump
+      TuleyShop.BlueMoon, Grapple, Blaze=1
       TuleyShop.SpringPlants, Hammer  # Uphammer Bounce
       TuleyShop.StickyGrass, Grapple, Sword OR Hammer OR Blaze=1 OR Shuriken=1 OR Sentry=1 OR Flash
       DoubleJump, Glide


### PR DESCRIPTION
Validation of `GladesTown`, `WindtornRuins` and `LowerReach` for Kii difficulty.

There is an added path in Moki that was probably forgotten (line 7811) ; and some changes in the connections to `TuleyShop` (fixes and added paths), in case this is still used in some situations.

I also moved the path in Wastes mentionned in Discord to unsafe
