### PR TITLE
Reorder requirements in Kii, some path changes, and minor syntax fixes in areas.wotw

### DIFF
--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -359,11 +359,15 @@ anchor MarshSpawn.BurrowFightArena at -959, -4406:  # at the right side of the B
     kii:
       Burrow, Water, Sword OR Hammer OR Glide OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=10
       Burrow, Damage=40
-      Burrow, Damage=30, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Burrow, WaterDash, Damage=20, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Burrow, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=30
+      Burrow, WaterDash, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=20
     unsafe:
-      Burrow, WaterDash, Damage=10, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1
-      Burrow, Damage=20, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1  # burrow as you exit the sand to exit the water before the 2nd water tick
+      Burrow, WaterDash, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1:
+        Damage=10
+      Burrow, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1:  # burrow as you exit the sand to exit the water before the 2nd water tick
+        Damage=20
       Burrow, Water, PauseHover OR BlazeSwap=1
 
 anchor MarshSpawn.LifepactLedge at -931, -4399:  # At the ledge in front of the door blocking Life Pact
@@ -418,6 +422,12 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Bash, Damage=40
     unsafe:
       DoubleJump, TripleJump  # more hardcore parkour
+      # The following path use a projectile to reach the first lantern
+      Bash, Damage=10 OR Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR PauseHover
+      # Same path as above, but dboost before the first lantern
+      # Bash, Damage=20  # dboost before the first lantern, and at the end
+      # Bash, Damage=10, Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1  # dboost before the first lantern
+      # Bash, Shuriken=2 OR Sentry=2 OR Flash=2
 
   conn MarshSpawn.BeforeBurrows:
     moki: Bash, DoubleJump OR Dash OR Launch
@@ -432,7 +442,7 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Launch, DoubleJump, Shuriken=1
       Launch, Dash, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1  # energy stall harder if you bonk into the ceiling inbetween the bashable plant but that actually reset your launch
       Launch, Sword, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
-      Bash, Damage=10, Sword OR Hammer  # use upsalsh inbetween the two lanterns. Not mandatory but players will probably use it there.
+      Bash, Damage=10, Sword OR Hammer  # use upslash inbetween the two lanterns. Not mandatory but players will probably use it there.
       Bash, Damage=10, Shuriken=3 OR Sentry=3  # one before the first lantern, one inbetween the two lantern (not mandatory) and a final one with a bash glide
       Bash, Damage=20, Blaze=3 OR Flash=2  # disable Flash inbetween the two lanterns
       Bash, Spear=3, Damage=30  # two dboost before the first lantern (because spear momentum can screw you up) and one at the end with a bash glide
@@ -440,6 +450,10 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
     unsafe:
       Bash, Sword OR Hammer
       Bash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=10 OR PauseHover  # use a projectile to reach the first lantern
+      # Same paths as above, but dboost before the first lantern
+      # Bash, Damage=20  # dboost before the first lantern, and at the end
+      # Bash, Damage=10, Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1  # dboost before the first lantern
+      # Bash, Shuriken=2 OR Sentry=2 OR Flash=2
       Launch  # Enough ledges to regain launch
       DoubleJump, TripleJump  # hardcore parkour
       GrenadeJump, DoubleJump, Bash OR Glide OR Damage=10 OR PauseHover  # Triple Grenade Jump is possible but redundant
@@ -458,7 +472,7 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Combat=Bat+Slug, Damage=10, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Damage=10, DoubleJump OR Sword OR Hammer  # dboost on the bat's projectile
       Damage=10, Combat=Slug, Spear=3 OR Shuriken=3 OR Flash=3 OR Sentry=3  # dboost on bat's projectile
-      Damage=10, Damage=10, Combat=Slug, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # dboost on bat's projectile then  in the spikes inbetween the slime and the bat
+      Damage=10, Damage=10, Combat=Slug, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # dboost on bat's projectile then in the spikes inbetween the slime and the bat
       Bash, Spear=3 OR Shuriken=3 OR Flash=3 OR Sentry=3
       Bash, Damage=10, Damage=10 OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
     unsafe: free  # microledge at the spikes above the slime
@@ -1047,7 +1061,8 @@ anchor HowlsDen.OutsideSecretRoom at -495, -4481:  # in front of the breakable w
       Water, WaterDash, HammerSJump=1
     kii:
       Hammer
-      Damage=10, Shuriken=1 OR Flash=1 OR Sentry=1
+      Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       Sentry=3  # two sentries in the air to avoid spikes
       WaterDash, Damage=10, Damage=10
       HowlsDen.RainLifted, Bash, Grenade=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # Slime only spawn when the rain is lifted
@@ -1113,7 +1128,8 @@ anchor HowlsDen.LeftSecretRoom at -565, -4470:  # Top of the elbow after the mos
     kii:
       Glide OR Sword OR Hammer OR Spear=3 OR Shuriken=3 OR Flash=3 OR Sentry=3
       Damage=10, Spear=2 OR Shuriken=2 OR Blaze=2 OR Flash=2 OR Sentry=2
-      Damage=10, Damage=10, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Damage=10, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       Bash, Shuriken=2 OR Flash=2 OR Sentry=2  # Bash the slug to reach the suspended platform. No Spear because it one shot the slug in easy
       Bash, Damage=10, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=10
     unsafe:
@@ -3291,15 +3307,14 @@ anchor EastHollow.Kwolok at 177, -4215:  # Between Ku and Kwolok
       Water, Grapple, DoubleJump, TripleJump OR Sword OR Hammer
       Water, Grapple, Dash  # Eiher jump from the Grapple point and the Dash or use double Dash
       Water, WaterDash, DoubleJump, TripleJump
-      Water, WaterDash, DoubleJump, Dash, Damage=10  # Take boost on the left side
-      # @validator The path above could be using Dash OR Glide OR Sword OR Hammer instead of just Dash
+      Water, WaterDash, DoubleJump, Damage=10, Dash OR Glide  # Take boost on the left side
     kii:
       # Repeat each moki/gorlek path without Combat=Balloon since you can just bait it into taking a swim
       Water, Launch
       Water, Grapple, Dash
-      Water, Grapple, DoubleJump, Glide OR TripleJump OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
-      Water, WaterDash, DoubleJump, TripleJump OR Sword OR Hammer OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Water, WaterDash, DoubleJump, Damage=10, Dash OR Glide OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Water, Grapple, DoubleJump, Glide OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Water, WaterDash, DoubleJump, Sword OR Hammer OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
+      Water, WaterDash, DoubleJump, Damage=10, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       # Completely new paths
       Water, Grapple, Sword
       Water, Grapple, Hammer, Glide OR Shuriken=1 OR Flash=1 OR Sentry=1
@@ -3644,13 +3659,17 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       Dash, Hammer, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, TripleJump OR Dash
       Sword, DoubleJump, Damage=10
-      Combat=2xWeakSlug, DoubleJump, Damage=20, Blaze=1 OR Damage=10
-      Combat=2xWeakSlug, DoubleJump, Damage=10, Damage=10, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Combat=2xWeakSlug, DoubleJump, Damage=20, Blaze=1 OR Damage=10:
+        Damage=10
+      Combat=2xWeakSlug, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10, Damage=10
       Combat=2xWeakSlug, DoubleJump, Damage=10, Glide OR Hammer OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Combat=2xWeakSlug, DoubleJump, Glide, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       Bash, Damage=10, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, Damage=20
+      Combat=2xWeakSlug, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       SwordSJump=1, Damage=10
       HammerSJump=1, Damage=20
       Dash, Hammer
@@ -3844,10 +3863,14 @@ anchor GladesTown.AcornMoki at -347, -4182:  # At the moki near the cave
         DoubleJump, TripleJump
         Water, Shuriken=2 OR Blaze=3 OR Sentry=2
         Water, Damage=10, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
-        Damage=32, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2  # That partcular water only deals 4 damage per tic
-        WaterDash, Damage=16, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2
-        WaterDash, Damage=26, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
-        Damage=42, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
+        Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2:  # That partcular water only deals 4 damage per tic
+          Damage=32
+        WaterDash, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2:
+          Damage=16
+        WaterDash, Damage=10, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1:
+          Damage=16
+        Damage=10, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1:
+          Damage=32
         Water, Damage=10, Damage=10
         Damage=10, Damage=42
         WaterDash, Damage=10, Damage=26
@@ -4227,7 +4250,10 @@ anchor WestGlades.LowerPool at -642, -4112:  # The left edge of the lower pool i
     kii:
       DoubleJump, TripleJump, Bash OR Damage=20  # With Bash, use a tentacle projectile
       DoubleJump, TripleJump, Damage=10, Dash OR Glide OR Sword OR Hammer
-      DoubleJump, Damage=30, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2
+      DoubleJump, Damage=10, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2:
+        Damage=10
+      DoubleJump, Damage=20, Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       Grapple, Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       Bash, DoubleJump
@@ -4297,10 +4323,13 @@ anchor WestGlades.Center at -612, -4083:  # At the middle room connecting upper 
       SentryJump=1, Dash
     kii:
       Bash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=20
-      Combat=Tentacle, Damage=10:
-        DoubleJump, Damage=20, Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR Blaze=1
-        DoubleJump, Damage=10, TripleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Flash=2 OR Shuriken=2 OR Spear=2 OR Blaze=2
-        Damage=40, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR Shuriken=1
+      DoubleJump, Damage=20, Combat=Tentacle, Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR Blaze=1
+      DoubleJump, Damage=10, Combat=Tentacle, TripleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Flash=2 OR Shuriken=2 OR Spear=2 OR Blaze=2
+      Damage=40, Combat=Tentacle, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR Shuriken=1
+      # Same paths as above, but extra 10 damage because of the enemy
+      DoubleJump, Damage=30, Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR Blaze=1
+      DoubleJump, Damage=20, TripleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Flash=2 OR Shuriken=2 OR Spear=2 OR Blaze=2
+      Damage=50, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR Shuriken=1
     unsafe:
       DoubleJump, Sword, Damage=10
       SentryJump=1  # pogo on tentacle
@@ -4449,7 +4478,8 @@ anchor WestGlades.MillApproach at -705, -4065:  # At the ledge of the room openi
       HammerSJump=1, Glide OR Damage=20
     kii:
       Sword
-      Damage=20, Hammer OR Sentry=2 OR Damage=20
+      Hammer OR Sentry=2 OR Damage=20:
+        Damage=20
       Bash, Grenade=1, Hammer OR Sentry=2
       Hammer, Glide OR Grapple OR Shuriken=1 OR Flash=1 OR Sentry=1
       Glide, Grapple OR Shuriken=1 OR Flash=1 OR Sentry=1
@@ -4701,7 +4731,8 @@ anchor OuterWellspring.EntranceDoor at -856, -4058:  # Outside the door where yo
       Bash, Grenade=1, Glide
       Bash, Grenade=2, Sword OR Damage=20
     kii:
-      Damage=20, Bash OR DoubleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Damage=20
+      Bash OR DoubleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Damage=20:
+        Damage=20
       Hammer, DoubleJump OR Dash
       Dash, Glide, Sword OR Shuriken=1 OR Flash=1 OR Sentry=1
       Bash, Glide  # Bash glide from the slime on the wooden platform
@@ -4813,8 +4844,10 @@ anchor OuterWellspring.Basement at -939, -4114:  # Next to the corruption openin
       Damage=15, Water, WaterDash OR Bash OR SwordSJump=1  # Use the wheel above BasementEC. walljump after the damage to regrab the wheel and use the iframes to pass the spikes.
       OuterWellspring.EntranceDoorOpen, Bash OR Grapple
       OuterWellspring.EntranceDoorOpen, SwordSJump=1, Water OR Damage=60
-      OuterWellspring.EntranceDoorOpen, WaterDash, Combat=WeakSlug, Damage=15, Water OR Damage=20  # Jump from the small ground on the wheels opening
-      OuterWellspring.EntranceDoorOpen, WaterDash, Combat=WeakSlug, Blaze=2, Water OR Damage=20
+      OuterWellspring.EntranceDoorOpen, WaterDash, Water OR Damage=20:  # Jump from the small ground on the wheels opening
+        Damage=15, Combat=WeakSlug
+      OuterWellspring.EntranceDoorOpen, WaterDash, Water OR Damage=20:
+        Blaze=2, Combat=WeakSlug
 
 anchor OuterWellspring.AboveEntranceDoor at -837, -4026:  # at the crystal above the entrance door
   refill Energy=3:
@@ -4930,7 +4963,8 @@ anchor OuterWellspring.WestDoor at -892, -3992:  # Outside the door where you ex
       Grapple, DoubleJump  # grapple the plant on the left, hold up to make it appear on screen
       Grapple, OuterWellspring.WestDoorBlueMoonFree, Dash OR Sword
       Grapple, OuterWellspring.WestDoorBlueMoonFree, Damage=15, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Grapple, Bash, Grenade=1, Damage=15, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Grapple, Bash, Grenade=1, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=15
       Grapple, Bash, Grenade=1, Dash OR Glide OR Sword OR Sentry=2
       Bash, Grenade=1, SentryJump=1, DoubleJump, TripleJump
 
@@ -5611,7 +5645,7 @@ anchor InnerWellspring.DrainAreaEX at -1064, -3961:  # At DrainEX
       Dash, DoubleJump OR Sword OR Hammer
     unsafe:
       Dash, Shuriken=1 OR Flash=1 OR Sentry=1
-      Damage=20, Damage=20, Spear=1
+      Damage=20, Spear=1, Damage=20
       DoubleJump
       WaterDash, Damage=20
 
@@ -5664,7 +5698,8 @@ anchor InnerWellspring.DrainAreaExit at -1093, -3950:  # At the checkpoint in th
         Bash, Grenade=2
         Bash, Grenade=1, Damage=20  # dboost in dirty water. If you drained the water, dboost in spikes instead.
       InnerWellspring.DrainLever:
-        Damage=15, Spear=1 OR Shuriken=1 OR Blaze=3 OR Flash=1 OR Sentry=1 OR Damage=15
+        Spear=1 OR Shuriken=1 OR Blaze=3 OR Flash=1 OR Sentry=1 OR Damage=15:
+          Damage=15
         Bash, Grenade=2
         Bash, Grenade=1, Damage=15
       Bash, Grenade=1, Damage=80  # dboost in dirty water. If you drained the water, you can dboost in the spikes instead
@@ -6080,7 +6115,8 @@ anchor InnerWellspring.TopSecondRoom at -1141, -3698:  # Next to the corruption 
       Damage=85
       Water, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
         Combat=Miner OR Bash OR Damage=10
-      Damage=60, Combat=Miner, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Damage=60, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Combat=Miner
       Damage=60, Bash, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       Damage=70, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       Launch, DoubleJump OR Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1
@@ -6439,12 +6475,14 @@ anchor WoodsMain.BelowFourKeystoneRoom at 951, -4210:  # At the first leaf pile 
     kii:
       DoubleJump, Sword, Combat=Balloon OR Damage=20  # Pogo the first balloon
       DoubleJump, Combat=2xBalloon, Damage=15, Glide OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
-      DoubleJump, Damage=35, TripleJump OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
+      DoubleJump, Damage=20, Damage=35, TripleJump OR Glide OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1  # dboost 1st balloon, dboost in spikes + energy weapon + dboost 2nd balloon
     unsafe:
       DoubleJump, Sword  # Pogo the first balloon, avoid the second one and kill it with a pogo
       DoubleJump, HammerSJump=1  # DoubleJump + full sword combo + up slash from the breakable wall to reach the left platform
       DoubleJump, TripleJump, Combat=2xBalloon OR Damage=20
       DoubleJump, Dash
+      DoubleJump, Combat=2xBalloon, Damage=15
+      DoubleJump, Damage=20, Damage=35  # dboost 1st balloon, dboost in spikes + dboost 2nd balloon
       Launch  # use launch invincibility to avoid dboost from balloons
   conn WoodsMain.AfterKuMeet:
     moki:
@@ -6783,7 +6821,8 @@ anchor WoodsMain.PetrifiedHowl at 910, -4071:  # At silenced Howl
       Sword OR Hammer OR Sentry=3
       Blaze=3, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
       Damage=15, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Damage=15, Damage=15, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Damage=15, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=15
     unsafe: free  # Friendly spikes truly are the best friends of rando players
 
 # checkpoint at 824, -4068
@@ -8504,7 +8543,7 @@ anchor LowerReach.TrialStart at 64, -4045:  # At trial start
     moki: Glide
     kii:  # TP out after taking the pickup
       Launch, DoubleJump OR Dash OR Sword OR Hammer OR Sentry=3 OR Damage=20  # sentry where the two bomb slug are, walljump launch, 2 sentries
-      DoubleJump, TripleJump, Damage=20, Combat=BombSlug, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
+      DoubleJump, TripleJump, Combat=BombSlug, Damage=20, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
     unsafe:
       Launch, Shuriken=1 OR Flash=1 OR Sentry=1  # shuriken/flash/sentry before using launch
       DoubleJump, TripleJump, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=10  # dboost on the flying spikes, which only deal 10 damages
@@ -12552,13 +12591,15 @@ anchor LowerWastes.WestTP at 1456, -3997:  # At the Western Wastes TP
     kii:
       DoubleJump, Hammer OR Sword  # djump+upslash to climb the wall
       Burrow, Dash OR Hammer OR Shuriken=2
-      Burrow, Damage=30, Sword OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Burrow, Sword OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=30
       Burrow, Glide, Sword OR Flash=2 OR Sentry=2
       Burrow, Sword, Spear=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # upslash then energy weapon to pass over the spikes
       Grapple, Hammer
       Grapple, Sentry=2, Shuriken=1 OR Damage=30
       Grapple, Glide, Sword OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Grapple, Glide, Damage=30, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Grapple, Glide, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=30
       Grapple, Sword, Spear=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=30  # upslash then energy weapon to pass over the spikes
     unsafe:
       DoubleJump  # precise....? This is another rough path. Can turn it to triple jump to make it freeTM, or can add weapons
@@ -12749,7 +12790,8 @@ anchor LowerWastes.SandPot at 1726, -3990:  # To the left of the sand pot
       Bash, Hammer OR Spear=2  # break the slime's shell and bash it
       Dash, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Dash, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Dash, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Dash, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=30
     unsafe:
       DoubleJump, Spear=1
       Hammer, Spear=1
@@ -12883,7 +12925,8 @@ anchor LowerWastes.MinesEntrance at 1921, -4001:  # To the left of the ruins bre
       Grapple  # Grapple the wheel to avoid combat requirement.
     kii:
       Damage=40  # dboost in the spikes and the gorlek
-      Damage=30, Combat=MaceMiner+Mantis OR Bash
+      Combat=MaceMiner+Mantis OR Bash:
+        Damage=30
       DoubleJump, Hammer OR Shuriken=1 OR Blaze=3 OR Sentry=2
       Bash, Sword OR Hammer OR Shuriken=1 OR Blaze=3 OR Sentry=2
 
@@ -13439,10 +13482,12 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       # 2.a Reach the bashable lantern, take a dboost in the spikes under the 2nd sand bag in order to reach it
       # 2.b Use a bashnade in order to land on the ledge above the sand bag and simply djump to the 2nd sand bag
       # Then Bashnade + djump to reach the ore
-      Bash, Grenade=2, DoubleJump, Damage=30, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.a
-      Bash, Grenade=2, DoubleJump, Glide, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (with glide) + 2.a
+      Bash, Damage=30, Grenade=2, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.a + 2.a
+        Damage=30
+      Bash, Grenade=2, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.b (with glide) + 2.a
+        Damage=30
       Bash, Grenade=2, DoubleJump, Sentry=3, Damage=30  # 1.b (2 sentries) + 2.a
-      Bash, Grenade=3, DoubleJump, Damage=30  # 1.a + 2.b
+      Bash, Damage=30, Grenade=3, DoubleJump  # 1.a + 2.b
       Bash, Grenade=3, DoubleJump, Glide OR Sentry=2  # 1.b + 2.b
       Bash, Grenade=4, DoubleJump  # 1.b (bashnade near the spikes) + 2.b
 
@@ -13476,16 +13521,16 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       # 3.a Reach the second lantern and reach OutsideRuins from there
       # 3.b Use a bashnade to land in the spikes above the sand bag and djump from there to OutsideRuins
       Bash, Grenade=1, DoubleJump, Burrow OR TripleJump OR Dash OR Hammer  # 1.b + 2.a (but you can avoid the dboost) + 3.a
-      Bash, Grenade=1, DoubleJump, Damage=30, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.a + 2.a + 3.a
+      Bash, Damage=30, Grenade=1, DoubleJump, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.a + 2.a + 3.a
       Bash, Grenade=1, DoubleJump, Glide, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.b (with glide) + 2.a + 3.a
       Bash, Grenade=1, DoubleJump, Sword, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (with sword) + 2.a (energy to reach the lantern, avoid the dboost with an upslash) + 3.a (upslash to reach the lantern)
       Bash, Grenade=1, DoubleJump, Sentry=4, Damage=30  # 1.b (2 sentries) + 2.a + 3.a
-      Bash, Grenade=2, DoubleJump, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.b + 3.a
+      Bash, Damage=30, Grenade=2, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Sword  # 1.b + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Sentry=3  # 1.b (2 sentries) + 2.b + 3.a
       Bash, Grenade=3, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (bashnade near the spikes) + 2.b + 3.a
-      Bash, Grenade=3, DoubleJump, Damage=30, Damage=30  # 1.a + 2.b + 3.b
+      Bash, Damage=30, Grenade=3, DoubleJump, Damage=30  # 1.a + 2.b + 3.b
       Bash, Grenade=3, DoubleJump, Glide  # 1.b + 2.b + 3.b (but you can avoid the dboost with glide)
       Bash, Grenade=3, DoubleJump, Sentry=2, Damage=30  # 1.b (2 sentries) + 2.b + 3.b
       Bash, Grenade=4, DoubleJump, Damage=30  # 1.b (bashnade near the spikes) + 2.b + 3.b


### PR DESCRIPTION
Changes to requirement ordering in Kii.
The changes that are not a reordering are the following:
- `425` and `453`: add unsafe paths with bash (same as Kii paths, but with less dboosts)
- `3310`: **new Gorlek path**
- `3315`: remove redundant paths
- `3662`: add an extra dboost at the end to make it less precise
- `4253`: remove a dboost
- `6442`: add 20 damage to dboost the 2nd balloon
- `6484`: new unsafe paths with less dboosts

This also contains the syntax fixes from last pull request.
