### PR TITLE
Reorder requirements + syntax fixes

### DIFF
--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -4978,8 +4978,10 @@ anchor OuterWellspring.Basement at -939, -4114:  # Next to the corruption openin
       Damage=15, Water, WaterDash OR Bash OR SwordSJump=1  # Use the wheel above BasementEC. walljump after the damage to regrab the wheel and use the iframes to pass the spikes.
       OuterWellspring.EntranceDoorOpen, Bash OR Grapple
       OuterWellspring.EntranceDoorOpen, SwordSJump=1, Water OR Damage=60
-      OuterWellspring.EntranceDoorOpen, WaterDash, Combat=WeakSlug, Damage=15, Water OR Damage=20  # Jump from the small ground on the wheels opening
-      OuterWellspring.EntranceDoorOpen, WaterDash, Combat=WeakSlug, Blaze=2, Water OR Damage=20
+      OuterWellspring.EntranceDoorOpen, WaterDash, Water OR Damage=20:  # Jump from the small ground on the wheels opening
+        Damage=15, Combat=WeakSlug
+      OuterWellspring.EntranceDoorOpen, WaterDash, Water OR Damage=20:
+        Blaze=2, Combat=WeakSlug
 
 anchor OuterWellspring.AboveEntranceDoor at -837, -4026:  # at the crystal above the entrance door
   refill Energy=3:
@@ -5100,7 +5102,8 @@ anchor OuterWellspring.WestDoor at -892, -3991:  # Outside the door where you ex
       Grapple, DoubleJump  # grapple the plant on the left, hold up to make it appear on screen
       Grapple, OuterWellspring.WestDoorBlueMoonFree, Dash OR Sword
       Grapple, OuterWellspring.WestDoorBlueMoonFree, Damage=15, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Grapple, Bash, Grenade=1, Damage=15, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Grapple, Bash, Grenade=1, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=15
       Grapple, Bash, Grenade=1, Dash OR Glide OR Sword OR Sentry=2
       Bash, Grenade=1, SentryJump=1, DoubleJump, TripleJump
 
@@ -5798,7 +5801,7 @@ anchor InnerWellspring.DrainAreaEX at -1064, -3961:  # At DrainEX
       Dash, DoubleJump OR Sword OR Hammer
     unsafe:
       Dash, Shuriken=1 OR Flash=1 OR Sentry=1
-      Damage=20, Damage=20, Spear=1
+      Damage=20, Spear=1, Damage=20
       DoubleJump
       WaterDash, Damage=20
 
@@ -5851,7 +5854,8 @@ anchor InnerWellspring.DrainAreaExit at -1093, -3950:  # At the checkpoint in th
         Bash, Grenade=2
         Bash, Grenade=1, Damage=20  # dboost in dirty water. If you drained the water, dboost in spikes instead.
       InnerWellspring.DrainLever:
-        Damage=15, Spear=1 OR Shuriken=1 OR Blaze=3 OR Flash=1 OR Sentry=1 OR Damage=15
+        Spear=1 OR Shuriken=1 OR Blaze=3 OR Flash=1 OR Sentry=1 OR Damage=15:
+          Damage=15
         Bash, Grenade=2
         Bash, Grenade=1, Damage=15
       Bash, Grenade=1, Damage=80  # dboost in dirty water. If you drained the water, you can dboost in the spikes instead
@@ -6273,7 +6277,8 @@ anchor InnerWellspring.TopSecondRoom at -1141, -3698:  # Next to the corruption 
       Damage=85
       Water, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
         Combat=Miner OR Bash OR Damage=10
-      Damage=60, Combat=Miner, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Damage=60, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Combat=Miner
       Damage=60, Bash, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       Damage=70, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
       Launch, DoubleJump OR Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1
@@ -6682,12 +6687,14 @@ anchor WoodsMain.BelowFourKeystoneRoom at 951, -4210:  # At the first leaf pile 
     kii:
       DoubleJump, Sword, Combat=Balloon OR Damage=20  # Pogo the first balloon
       DoubleJump, Combat=2xBalloon, Damage=15, Glide OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
-      DoubleJump, Damage=35, TripleJump OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
+      DoubleJump, Damage=20, Damage=35, TripleJump OR Glide OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1  # dboost 1st balloon, dboost in spikes + energy weapon + dboost 2nd balloon
     unsafe:
       DoubleJump, Sword  # Pogo the first balloon, avoid the second one and kill it with a pogo
       DoubleJump, HammerSJump=1  # DoubleJump + full sword combo + up slash from the breakable wall to reach the left platform
       DoubleJump, TripleJump, Combat=2xBalloon OR Damage=20
       DoubleJump, Dash
+      DoubleJump, Combat=2xBalloon, Damage=15
+      DoubleJump, Damage=20, Damage=35  # dboost 1st balloon, dboost in spikes + dboost 2nd balloon
       Launch  # use launch invincibility to avoid dboost from balloons
   conn WoodsMain.AfterKuMeet:
     moki:
@@ -7022,7 +7029,8 @@ anchor WoodsMain.PetrifiedHowl at 910, -4071:  # At silenced Howl
       Sword OR Hammer OR Sentry=3
       Blaze=3, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
       Damage=15, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Damage=15, Damage=15, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Damage=15, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=15
     unsafe: free  # Friendly spikes truly are the best friends of rando players
 
 # checkpoint at 824, -4068
@@ -8746,7 +8754,7 @@ anchor LowerReach.TrialStart at 64, -4045:  # At trial start
     moki: Glide
     kii:  # TP out after taking the pickup
       Launch, DoubleJump OR Dash OR Sword OR Hammer OR Sentry=3 OR Damage=20  # sentry where the two bomb slug are, walljump launch, 2 sentries
-      DoubleJump, TripleJump, Damage=20, Combat=BombSlug, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
+      DoubleJump, TripleJump, Combat=BombSlug, Damage=20, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
     unsafe:
       Launch, Shuriken=1 OR Flash=1 OR Sentry=1  # shuriken/flash/sentry before using launch
       DoubleJump, TripleJump, Sword OR Dash OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=10  # dboost on the flying spikes, which only deal 10 damages
@@ -12875,13 +12883,15 @@ anchor LowerWastes.WestTP at 1456, -3997:  # At the Western Wastes TP
     kii:
       DoubleJump, Hammer OR Sword  # djump+upslash to climb the wall
       Burrow, Dash OR Hammer OR Shuriken=2
-      Burrow, Damage=30, Sword OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Burrow, Sword OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=30
       Burrow, Glide, Sword OR Flash=2 OR Sentry=2
       Burrow, Sword, Spear=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # upslash then energy weapon to pass over the spikes
       Grapple, Hammer
       Grapple, Sentry=2, Shuriken=1 OR Damage=30
       Grapple, Glide, Sword OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Grapple, Glide, Damage=30, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Grapple, Glide, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Damage=30
       Grapple, Sword, Spear=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=30  # upslash then energy weapon to pass over the spikes
     unsafe:
       DoubleJump  # precise....? This is another rough path. Can turn it to triple jump to make it freeTM, or can add weapons
@@ -13072,7 +13082,8 @@ anchor LowerWastes.SandPot at 1726, -3990:  # To the left of the sand pot
       Bash, Hammer OR Spear=2  # break the slime's shell and bash it
       Dash, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Dash, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Dash, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Dash, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=30
     unsafe:
       DoubleJump, Spear=1
       Hammer, Spear=1
@@ -13206,7 +13217,8 @@ anchor LowerWastes.MinesEntrance at 1921, -4001:  # To the left of the ruins bre
       Grapple  # Grapple the wheel to avoid combat requirement.
     kii:
       Damage=40  # dboost in the spikes and the gorlek
-      Damage=30, Combat=MaceMiner+Mantis OR Bash
+      Combat=MaceMiner+Mantis OR Bash:
+        Damage=30
       DoubleJump, Hammer OR Shuriken=1 OR Blaze=3 OR Sentry=2
       Bash, Sword OR Hammer OR Shuriken=1 OR Blaze=3 OR Sentry=2
 
@@ -13762,10 +13774,12 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       # 2.a Reach the bashable lantern, take a dboost in the spikes under the 2nd sand bag in order to reach it
       # 2.b Use a bashnade in order to land on the ledge above the sand bag and simply djump to the 2nd sand bag
       # Then Bashnade + djump to reach the ore
-      Bash, Grenade=2, DoubleJump, Damage=30, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.a
-      Bash, Grenade=2, DoubleJump, Glide, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (with glide) + 2.a
+      Bash, Damage=30, Grenade=2, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.a + 2.a
+        Damage=30
+      Bash, Grenade=2, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.b (with glide) + 2.a
+        Damage=30
       Bash, Grenade=2, DoubleJump, Sentry=3, Damage=30  # 1.b (2 sentries) + 2.a
-      Bash, Grenade=3, DoubleJump, Damage=30  # 1.a + 2.b
+      Bash, Damage=30, Grenade=3, DoubleJump  # 1.a + 2.b
       Bash, Grenade=3, DoubleJump, Glide OR Sentry=2  # 1.b + 2.b
       Bash, Grenade=4, DoubleJump  # 1.b (bashnade near the spikes) + 2.b
 
@@ -13799,16 +13813,16 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       # 3.a Reach the second lantern and reach OutsideRuins from there
       # 3.b Use a bashnade to land in the spikes above the sand bag and djump from there to OutsideRuins
       Bash, Grenade=1, DoubleJump, Burrow OR TripleJump OR Dash OR Hammer  # 1.b + 2.a (but you can avoid the dboost) + 3.a
-      Bash, Grenade=1, DoubleJump, Damage=30, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.a + 2.a + 3.a
+      Bash, Damage=30, Grenade=1, DoubleJump, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.a + 2.a + 3.a
       Bash, Grenade=1, DoubleJump, Glide, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.b (with glide) + 2.a + 3.a
       Bash, Grenade=1, DoubleJump, Sword, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (with sword) + 2.a (energy to reach the lantern, avoid the dboost with an upslash) + 3.a (upslash to reach the lantern)
       Bash, Grenade=1, DoubleJump, Sentry=4, Damage=30  # 1.b (2 sentries) + 2.a + 3.a
-      Bash, Grenade=2, DoubleJump, Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.b + 3.a
+      Bash, Damage=30, Grenade=2, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Sword  # 1.b + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Sentry=3  # 1.b (2 sentries) + 2.b + 3.a
       Bash, Grenade=3, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (bashnade near the spikes) + 2.b + 3.a
-      Bash, Grenade=3, DoubleJump, Damage=30, Damage=30  # 1.a + 2.b + 3.b
+      Bash, Damage=30, Grenade=3, DoubleJump, Damage=30  # 1.a + 2.b + 3.b
       Bash, Grenade=3, DoubleJump, Glide  # 1.b + 2.b + 3.b (but you can avoid the dboost with glide)
       Bash, Grenade=3, DoubleJump, Sentry=2, Damage=30  # 1.b (2 sentries) + 2.b + 3.b
       Bash, Grenade=4, DoubleJump, Damage=30  # 1.b (bashnade near the spikes) + 2.b + 3.b

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -272,7 +272,7 @@ anchor MarshSpawn.Cave at -707, -4419:  # At Tokk in the Cave
     gorlek: ShurikenBreak=16
     unsafe: HammerBreak OR SpearBreak
   state MarshSpawn.CaveFight:
-    Combat=3xLizard  # at day there's two extra lizards
+    moki: Combat=3xLizard  # at day there's two extra lizards
 
   quest MarshSpawn.CaveKS:
     moki:
@@ -363,11 +363,15 @@ anchor MarshSpawn.BurrowFightArena at -959, -4406:  # at the right side of the B
     kii:
       Burrow, Water, Sword OR Hammer OR Glide OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=10
       Burrow, Damage=40
-      Burrow, Damage=30, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Burrow, WaterDash, Damage=20, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Burrow, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=30
+      Burrow, WaterDash, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=20
     unsafe:
-      Burrow, WaterDash, Damage=10, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1
-      Burrow, Damage=20, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1  # burrow as you exit the sand to exit the water before the 2nd water tick
+      Burrow, WaterDash, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1:
+        Damage=10
+      Burrow, DoubleJump OR Dash OR Launch OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR PauseHover OR BlazeSwap=1:  # burrow as you exit the sand to exit the water before the 2nd water tick
+        Damage=20
       Burrow, Water, PauseHover OR BlazeSwap=1
 
 anchor MarshSpawn.LifepactLedge at -931, -4399:  # At the ledge in front of the door blocking Life Pact
@@ -422,6 +426,12 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Bash, Damage=40
     unsafe:
       DoubleJump, TripleJump  # more hardcore parkour
+      # The following path use a projectile to reach the first lantern
+      Bash, Damage=10 OR Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR PauseHover
+      # Same path as above, but dboost before the first lantern
+      # Bash, Damage=20  # dboost before the first lantern, and at the end
+      # Bash, Damage=10, Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1  # dboost before the first lantern
+      # Bash, Shuriken=2 OR Sentry=2 OR Flash=2
 
   conn MarshSpawn.BeforeBurrows:
     moki: Bash, DoubleJump OR Dash OR Launch
@@ -436,7 +446,7 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Launch, DoubleJump, Shuriken=1
       Launch, Dash, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1  # energy stall harder if you bonk into the ceiling inbetween the bashable plant but that actually reset your launch
       Launch, Sword, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
-      Bash, Damage=10, Sword OR Hammer  # use upsalsh inbetween the two lanterns. Not mandatory but players will probably use it there.
+      Bash, Damage=10, Sword OR Hammer  # use upslash inbetween the two lanterns. Not mandatory but players will probably use it there.
       Bash, Damage=10, Shuriken=3 OR Sentry=3  # one before the first lantern, one inbetween the two lantern (not mandatory) and a final one with a bash glide
       Bash, Damage=20, Blaze=3 OR Flash=2  # disable Flash inbetween the two lanterns
       Bash, Spear=3, Damage=30  # two dboost before the first lantern (because spear momentum can screw you up) and one at the end with a bash glide
@@ -444,6 +454,10 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
     unsafe:
       Bash, Sword OR Hammer
       Bash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=10 OR PauseHover  # use a projectile to reach the first lantern
+      # Same paths as above, but dboost before the first lantern
+      # Bash, Damage=20  # dboost before the first lantern, and at the end
+      # Bash, Damage=10, Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1  # dboost before the first lantern
+      # Bash, Shuriken=2 OR Sentry=2 OR Flash=2
       Launch  # Enough ledges to regain launch
       DoubleJump, TripleJump  # hardcore parkour
       GrenadeJump, DoubleJump, Bash OR Glide OR Damage=10 OR PauseHover  # Triple Grenade Jump is possible but redundant
@@ -462,7 +476,7 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Combat=Bat+Slug, Damage=10, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Damage=10, DoubleJump OR Sword OR Hammer  # dboost on the bat's projectile
       Damage=10, Combat=Slug, Spear=3 OR Shuriken=3 OR Flash=3 OR Sentry=3  # dboost on bat's projectile
-      Damage=10, Damage=10, Combat=Slug, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # dboost on bat's projectile then  in the spikes inbetween the slime and the bat
+      Damage=10, Damage=10, Combat=Slug, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # dboost on bat's projectile then in the spikes inbetween the slime and the bat
       Bash, Spear=3 OR Shuriken=3 OR Flash=3 OR Sentry=3
       Bash, Damage=10, Damage=10 OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
     unsafe: free  # microledge at the spikes above the slime
@@ -1057,7 +1071,8 @@ anchor HowlsDen.OutsideSecretRoom at -495, -4481:  # in front of the breakable w
       Water, WaterDash, HammerSJump=1
     kii:
       Hammer
-      Damage=10, Shuriken=1 OR Flash=1 OR Sentry=1
+      Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       Sentry=3  # two sentries in the air to avoid spikes
       WaterDash, Damage=10, Damage=10
       HowlsDen.RainLifted, Bash, Grenade=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # Slime only spawn when the rain is lifted
@@ -1124,7 +1139,7 @@ anchor HowlsDen.LeftSecretRoom at -565, -4470:  # Top of the elbow after the mos
       Glide OR Sword OR Hammer OR Spear=3 OR Shuriken=3 OR Flash=3 OR Sentry=3
       Damage=10, Spear=2 OR Shuriken=2 OR Blaze=2 OR Flash=2 OR Sentry=2
       Damage=10, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
-          Damage=10
+        Damage=10
       Bash, Shuriken=2 OR Flash=2 OR Sentry=2  # Bash the slug to reach the suspended platform. No Spear because it one shot the slug in easy
       Bash, Damage=10, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=10
     unsafe:
@@ -3691,13 +3706,17 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       Dash, Hammer, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, TripleJump OR Dash
       Sword, DoubleJump, Damage=10
-      Combat=2xWeakSlug, DoubleJump, Damage=20, Blaze=1 OR Damage=10
-      Combat=2xWeakSlug, DoubleJump, Damage=10, Damage=10, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Combat=2xWeakSlug, DoubleJump, Damage=10, Glide OR Hammer OR Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
+      Combat=2xWeakSlug, DoubleJump, Damage=10 OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1:
+        Damage=20
+      Combat=2xWeakSlug, DoubleJump, Damage=10 OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1:
+        Damage=10, Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
+      Combat=2xWeakSlug, DoubleJump, Damage=10, Glide OR Hammer
       Combat=2xWeakSlug, DoubleJump, Glide, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       Bash, Damage=10, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, Damage=20
+      Combat=2xWeakSlug, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       SwordSJump=1, Damage=10
       HammerSJump=1, Damage=20
       Dash, Hammer
@@ -3962,8 +3981,10 @@ anchor GladesTown.AcornCave at -50, -4510: # Inside the cave with the acorn at t
         Water, Damage=10, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
         Damage=32, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2  # That partcular water only deals 4 damage per tic
         WaterDash, Damage=16, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2
-        WaterDash, Damage=26, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
-        Damage=42, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
+        WaterDash, Damage=10, Shuriken=1 OR Sentry=2 OR Blaze=2:
+          Damage=16
+        Damage=10, Shuriken=1 OR Sentry=2 OR Blaze=2:
+          Damage=32
         Water, Damage=10, Damage=10
         Damage=10, Damage=42
         WaterDash, Damage=10, Damage=26
@@ -4350,7 +4371,10 @@ anchor WestGlades.LowerPool at -642, -4112:  # The left edge of the lower pool i
     kii:
       DoubleJump, TripleJump, Bash OR Damage=20  # With Bash, use a tentacle projectile
       DoubleJump, TripleJump, Damage=10, Dash OR Glide OR Sword OR Hammer
-      DoubleJump, Damage=30, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2
+      DoubleJump, Damage=10, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2:
+        Damage=10
+      DoubleJump, Damage=20, Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       Grapple, Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       Bash, DoubleJump
@@ -4429,10 +4453,12 @@ anchor WestGlades.Center at -612, -4083:  # At the middle room connecting upper 
       SentryJump=1, Dash
     kii:
       Bash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=20
-      Combat=Tentacle, Damage=10:
-        DoubleJump, Damage=20, Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR Blaze=1
-        DoubleJump, Damage=10, TripleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Flash=2 OR Shuriken=2 OR Spear=2 OR Blaze=2
-        Damage=40, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR Shuriken=1
+      DoubleJump, Damage=30, Combat=Tentacle, Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR Blaze=1
+      DoubleJump, Damage=20, Combat=Tentacle, TripleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Flash=2 OR Shuriken=2 OR Spear=2 OR Blaze=2
+      Damage=50, Combat=Tentacle, Dash, Sword OR Hammer OR Sentry=1 OR Flash=1 OR Shuriken=1
+      # Same paths as above, but extra 10 damage because of the enemy
+      DoubleJump, Damage=40, Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR Blaze=1
+      DoubleJump, Damage=30, TripleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Flash=2 OR Shuriken=2 OR Spear=2 OR Blaze=2
     unsafe:
       DoubleJump, Sword, Damage=10
       SentryJump=1  # pogo on tentacle
@@ -4581,7 +4607,8 @@ anchor WestGlades.MillApproach at -705, -4065:  # At the ledge of the room openi
       HammerSJump=1, Glide OR Damage=20
     kii:
       Sword
-      Damage=20, Hammer OR Sentry=2 OR Damage=20
+      Hammer OR Sentry=2 OR Damage=20:
+        Damage=20
       Bash, Grenade=1, Hammer OR Sentry=2
       Hammer, Glide OR Grapple OR Shuriken=1 OR Flash=1 OR Sentry=1
       Glide, Grapple OR Shuriken=1 OR Flash=1 OR Sentry=1
@@ -4838,7 +4865,8 @@ anchor OuterWellspring.EntranceDoor at -856, -4057:  # Outside the door where yo
       Bash, Grenade=1, Glide
       Bash, Grenade=2, Sword OR Damage=20
     kii:
-      Damage=20, Bash OR DoubleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Damage=20
+      Bash OR DoubleJump OR Dash OR Sword OR Hammer OR Sentry=2 OR Damage=20:
+        Damage=20
       Hammer, DoubleJump OR Dash
       Dash, Glide, Sword OR Shuriken=1 OR Flash=1 OR Sentry=1
       Bash, Glide  # Bash glide from the slime on the wooden platform
@@ -11176,7 +11204,7 @@ anchor EastPools.LeverRoom at -1160, -4152:  # At the amulet Moki
 
   pickup EastPools.TwoCrushersEX:
     moki: Water, WaterDash
-    kii, WaterDash, Damage=40
+    kii: WaterDash, Damage=40
     unsafe:
       Water OR Damage=100
       WaterDash, Damage=20
@@ -12422,7 +12450,7 @@ anchor UpperPools.DrainPuzzleEntrance at -1386, -4062:  # At the right of the do
 
 anchor UpperPools.DrainPuzzleRight at -1324, -4060:  # On the ground next to the energy cristal
   refill Energy=3:
-     moki: BreakCrystal
+    moki: BreakCrystal
   refill Health=1
 
   # TODO: optimize water damage with underwater TP
@@ -12695,7 +12723,7 @@ anchor WestPools.Teleporter at -1656, -4171:  # the west Pools TP
   pickup WestPools.BurrowOre:  # intended path omitted in moki, as some players cannot reach this in time even with all skills
     gorlek: WestPools.ForestsStrength, Water, WaterDash, Burrow
     kii: WestPools.ForestsStrength, Damage=100, Damage=80, Damage=100, WaterDash, Burrow
-    unsafe: WestPools.ForestsStrength:
+    unsafe, WestPools.ForestsStrength:
       Water, Burrow
       Damage=80, Damage=60, Damage=80, WaterDash, Burrow
 

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -426,12 +426,6 @@ anchor MarshSpawn.PoolsBurrowsSignpost at -898, -4436:  # the waypoint between p
       Bash, Damage=40
     unsafe:
       DoubleJump, TripleJump  # more hardcore parkour
-      # The following path use a projectile to reach the first lantern
-      Bash, Damage=10 OR Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1 OR PauseHover
-      # Same path as above, but dboost before the first lantern
-      # Bash, Damage=20  # dboost before the first lantern, and at the end
-      # Bash, Damage=10, Blaze=1 OR Sentry=1 OR Flash=1 OR Shuriken=1 OR Spear=1  # dboost before the first lantern
-      # Bash, Shuriken=2 OR Sentry=2 OR Flash=2
 
   conn MarshSpawn.BeforeBurrows:
     moki: Bash, DoubleJump OR Dash OR Launch
@@ -3706,23 +3700,24 @@ anchor GladesTown.West at -430, -4135:  # Path exiting the village, above Twille
       Dash, Hammer, Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, TripleJump OR Dash
       Sword, DoubleJump, Damage=10
-      Combat=2xWeakSlug, DoubleJump, Damage=10 OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1:
+      Combat=2xWeakSlug, DoubleJump, Damage=10 OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
         Damage=20
-      Combat=2xWeakSlug, DoubleJump, Damage=10 OR Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1:
-        Damage=10, Shuriken=1 OR Sentry=1 OR Flash=1 OR Spear=1
+        Damage=10, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
       Combat=2xWeakSlug, DoubleJump, Damage=10, Glide OR Hammer
       Combat=2xWeakSlug, DoubleJump, Glide, Sword OR Hammer OR Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       Bash, Damage=10, Shuriken=1 OR Flash=1 OR Sentry=1
-      Combat=2xWeakSlug, DoubleJump, Damage=20
-      Combat=2xWeakSlug, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+      Combat=2xWeakSlug, DoubleJump, Damage=10 OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
         Damage=10
+      Combat=2xWeakSlug, PauseHover, Damage=10
+      Combat=2xWeakSlug, DoubleJump, Glide
       SwordSJump=1, Damage=10
       HammerSJump=1, Damage=20
       Dash, Hammer
       #Dash, Sword, Damage=30  # damage depending on how often you fail the last jump (10 is minimum)
       Damage=10, Bash OR Sword
-      DoubleJump, Damage=10, TripleJump OR Dash  # damage for avoiding slimes
+      DoubleJump, Dash, Damage=10  # damage for avoiding slimes
+      DoubleJump, TripleJump OR Sword OR Hammer
   conn GladesTown.TwillenHome: free
   conn GladesTown.Teleporter:
     moki:
@@ -3979,7 +3974,7 @@ anchor GladesTown.AcornCave at -50, -4510: # Inside the cave with the acorn at t
         DoubleJump, TripleJump
         Water, Shuriken=2 OR Blaze=3 OR Sentry=2
         Water, Damage=10, Shuriken=1 OR Blaze=1 OR Sentry=1 OR Spear=1
-        Damage=32, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2  # That partcular water only deals 4 damage per tic
+        Damage=32, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2  # That particular water only deals 4 damage per tic
         WaterDash, Damage=16, Glide OR DoubleJump OR Dash OR Sword OR Hammer OR Shuriken=2 OR Blaze=3 OR Sentry=2
         WaterDash, Damage=10, Shuriken=1 OR Sentry=2 OR Blaze=2:
           Damage=16
@@ -3991,7 +3986,7 @@ anchor GladesTown.AcornCave at -50, -4510: # Inside the cave with the acorn at t
       Bow=4, DoubleJump, TripleJump
     unsafe:
       Flash:
-        Water # use Flash for mobility as well
+        Water OR Damage=36  # use Flash for mobility as well
         GrenadeJump
       Bow=2:
         Launch
@@ -4371,16 +4366,17 @@ anchor WestGlades.LowerPool at -642, -4112:  # The left edge of the lower pool i
     kii:
       DoubleJump, TripleJump, Bash OR Damage=20  # With Bash, use a tentacle projectile
       DoubleJump, TripleJump, Damage=10, Dash OR Glide OR Sword OR Hammer
-      DoubleJump, Damage=10, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2:
-        Damage=10
-      DoubleJump, Damage=20, Shuriken=1 OR Flash=1 OR Sentry=1:
-        Damage=10
+      DoubleJump, Damage=30, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2
       Grapple, Shuriken=1 OR Flash=1 OR Sentry=1
     unsafe:
       Bash, DoubleJump
       Grapple, Spear=1 OR Blaze=1 OR Damage=20
       Bash, Glide, SwordSJump=1
       DoubleJump, TripleJump, Glide OR Sword OR Hammer OR Damage=10 OR Shuriken=2 OR Sentry=2
+      DoubleJump, Damage=10, Dash OR Sword OR Hammer OR Shuriken=2 OR Flash=2 OR Sentry=2:
+        Damage=10
+      DoubleJump, Damage=20, Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=10
       GrenadeJump, DoubleJump OR Dash OR SentryJump=1 OR Damage=10
       SentryJump=2
   pickup WestGlades.SwimEC:
@@ -4607,7 +4603,7 @@ anchor WestGlades.MillApproach at -705, -4065:  # At the ledge of the room openi
       HammerSJump=1, Glide OR Damage=20
     kii:
       Sword
-      Hammer OR Sentry=2 OR Damage=20:
+      Hammer OR Blaze=4 OR Sentry=2 OR Damage=20:
         Damage=20
       Bash, Grenade=1, Hammer OR Sentry=2
       Hammer, Glide OR Grapple OR Shuriken=1 OR Flash=1 OR Sentry=1
@@ -4979,9 +4975,8 @@ anchor OuterWellspring.Basement at -939, -4114:  # Next to the corruption openin
       OuterWellspring.EntranceDoorOpen, Bash OR Grapple
       OuterWellspring.EntranceDoorOpen, SwordSJump=1, Water OR Damage=60
       OuterWellspring.EntranceDoorOpen, WaterDash, Water OR Damage=20:  # Jump from the small ground on the wheels opening
-        Damage=15, Combat=WeakSlug
-      OuterWellspring.EntranceDoorOpen, WaterDash, Water OR Damage=20:
-        Blaze=2, Combat=WeakSlug
+        Damage=15, Combat=WeakSlug OR Damage=5  # dboost on a slug projectile
+        Blaze=2, Combat=WeakSlug OR Damage=5
 
 anchor OuterWellspring.AboveEntranceDoor at -837, -4026:  # at the crystal above the entrance door
   refill Energy=3:
@@ -5800,10 +5795,8 @@ anchor InnerWellspring.DrainAreaEX at -1064, -3961:  # At DrainEX
       WaterDash, Damage=20, Bash OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1 OR Damage=20
       Dash, DoubleJump OR Sword OR Hammer
     unsafe:
-      Dash, Shuriken=1 OR Flash=1 OR Sentry=1
-      Damage=20, Spear=1, Damage=20
-      DoubleJump
-      WaterDash, Damage=20
+      Damage=15, WaterDash OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1  # dboost in the spikes above the first log to avoid a water tick then precise jump from the second log to grab the wheel without touching the spikes
+      DoubleJump OR Dash
 
   conn InnerWellspring.DrainAreaExit:
     moki, BreakWall=10:
@@ -6275,12 +6268,10 @@ anchor InnerWellspring.TopSecondRoom at -1141, -3698:  # Next to the corruption 
       Water, Damage=10, DoubleJump OR Dash OR Sword OR Hammer
       Damage=75, Combat=Miner OR Bash
       Damage=85
-      Water, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
-        Combat=Miner OR Bash OR Damage=10
-      Damage=60, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
-        Combat=Miner
-      Damage=60, Bash, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
-      Damage=70, Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1
+      Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
+        Water, Combat=Miner OR Bash OR Damage=10
+        Damage=60, Combat=Miner OR Bash
+        Damage=70
       Launch, DoubleJump OR Dash OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=2 OR Flash=1 OR Sentry=1
     unsafe:
       Launch  # There is a small ledge on the ceiling to reset launch
@@ -6691,10 +6682,8 @@ anchor WoodsMain.BelowFourKeystoneRoom at 951, -4210:  # At the first leaf pile 
     unsafe:
       DoubleJump, Sword  # Pogo the first balloon, avoid the second one and kill it with a pogo
       DoubleJump, HammerSJump=1  # DoubleJump + full sword combo + up slash from the breakable wall to reach the left platform
-      DoubleJump, TripleJump, Combat=2xBalloon OR Damage=20
-      DoubleJump, Dash
-      DoubleJump, Combat=2xBalloon, Damage=15
-      DoubleJump, Damage=20, Damage=35  # dboost 1st balloon, dboost in spikes + dboost 2nd balloon
+      DoubleJump, TripleJump OR Dash
+      DoubleJump, Damage=15  # https://youtu.be/5OAN8TzrH4k
       Launch  # use launch invincibility to avoid dboost from balloons
   conn WoodsMain.AfterKuMeet:
     moki:
@@ -7031,6 +7020,7 @@ anchor WoodsMain.PetrifiedHowl at 910, -4071:  # At silenced Howl
       Damage=15, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
       Damage=15, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1:
         Damage=15
+      Damage=30, Damage=15
     unsafe: free  # Friendly spikes truly are the best friends of rando players
 
 # checkpoint at 824, -4068
@@ -13088,8 +13078,7 @@ anchor LowerWastes.SandPot at 1726, -3990:  # To the left of the sand pot
       DoubleJump, Spear=1
       Hammer, Spear=1
       Bash, Spear=1  # break the slime's shell and bash it
-      Dash, Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=30
-      Dash, Burrow  # burrow in the sand pot so you can dash into the ceiling to reset your dash
+      Dash  # Coyote dash from the top of the pot
       Glide  # climb on the sand pot from the right then hover
 
 anchor LowerWastes.WoodenBridge at 1796, -3977:  # Directly above MuncherPitEX
@@ -13774,11 +13763,11 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       # 2.a Reach the bashable lantern, take a dboost in the spikes under the 2nd sand bag in order to reach it
       # 2.b Use a bashnade in order to land on the ledge above the sand bag and simply djump to the 2nd sand bag
       # Then Bashnade + djump to reach the ore
-      Bash, Damage=30, Grenade=2, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.a + 2.a
-        Damage=30
-      Bash, Grenade=2, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.b (with glide) + 2.a
-        Damage=30
-      Bash, Grenade=2, DoubleJump, Sentry=3, Damage=30  # 1.b (2 sentries) + 2.a
+      Bash, Damage=30, Grenade=1, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.a + 2.a
+        Damage=30, Grenade=1
+      Bash, Grenade=1, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:  # 1.b (with glide) + 2.a
+        Damage=30, Grenade=1
+      Bash, Grenade=1, DoubleJump, Sentry=3, Damage=30, Grenade=1  # 1.b (2 sentries) + 2.a
       Bash, Damage=30, Grenade=3, DoubleJump  # 1.a + 2.b
       Bash, Grenade=3, DoubleJump, Glide OR Sentry=2  # 1.b + 2.b
       Bash, Grenade=4, DoubleJump  # 1.b (bashnade near the spikes) + 2.b
@@ -13813,10 +13802,12 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       # 3.a Reach the second lantern and reach OutsideRuins from there
       # 3.b Use a bashnade to land in the spikes above the sand bag and djump from there to OutsideRuins
       Bash, Grenade=1, DoubleJump, Burrow OR TripleJump OR Dash OR Hammer  # 1.b + 2.a (but you can avoid the dboost) + 3.a
-      Bash, Damage=30, Grenade=1, DoubleJump, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.a + 2.a + 3.a
-      Bash, Grenade=1, DoubleJump, Glide, Damage=30, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2  # 1.b (with glide) + 2.a + 3.a
+      Bash, Damage=30, Grenade=1, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.a + 3.a
+      Bash, Grenade=1, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+        Damage=30, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (with glide) + 2.a + 3.a
       Bash, Grenade=1, DoubleJump, Sword, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (with sword) + 2.a (energy to reach the lantern, avoid the dboost with an upslash) + 3.a (upslash to reach the lantern)
-      Bash, Grenade=1, DoubleJump, Sentry=4, Damage=30  # 1.b (2 sentries) + 2.a + 3.a
+      Bash, Grenade=1, DoubleJump, Sentry=3, Damage=30, Sentry=1  # 1.b (2 sentries) + 2.a + 3.a
       Bash, Damage=30, Grenade=2, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.a + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Sword  # 1.b + 2.b + 3.a
       Bash, Grenade=2, DoubleJump, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b + 2.b + 3.a
@@ -13824,7 +13815,6 @@ anchor UpperWastes.NorthTP at 2044, -3679:  # Left of the teleporter, on top of 
       Bash, Grenade=3, DoubleJump, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1  # 1.b (bashnade near the spikes) + 2.b + 3.a
       Bash, Damage=30, Grenade=3, DoubleJump, Damage=30  # 1.a + 2.b + 3.b
       Bash, Grenade=3, DoubleJump, Glide  # 1.b + 2.b + 3.b (but you can avoid the dboost with glide)
-      Bash, Grenade=3, DoubleJump, Sentry=2, Damage=30  # 1.b (2 sentries) + 2.b + 3.b
       Bash, Grenade=4, DoubleJump, Damage=30  # 1.b (bashnade near the spikes) + 2.b + 3.b
     unsafe:
       Bash, Grenade=1, DoubleJump, Glide OR Sword OR Shuriken=1 OR Sentry=2 OR Damage=30

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -13070,16 +13070,16 @@ anchor LowerWastes.SandPot at 1726, -3990:  # To the left of the sand pot
       Grapple, DoubleJump OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR Damage=30
       Bash, Grenade=1
       Bash, Hammer OR Spear=2  # break the slime's shell and bash it
-      Dash, Spear=2 OR Shuriken=2 OR Flash=2 OR Sentry=2
-      Dash, Glide, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Dash, Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1:
+      Dash, Spear=2 OR Flash=2 OR Sentry=2
+      Dash, Glide, Spear=1 OR Flash=1 OR Sentry=1
+      Dash, Spear=1 OR Flash=1 OR Sentry=1:
         Damage=30
     unsafe:
       DoubleJump, Spear=1
       Hammer, Spear=1
       Bash, Spear=1  # break the slime's shell and bash it
       Dash  # Coyote dash from the top of the pot
-      Glide  # climb on the sand pot from the right then hover
+      Glide OR PauseHover  # climb on the sand pot from the right then hover
 
 anchor LowerWastes.WoodenBridge at 1796, -3977:  # Directly above MuncherPitEX
   refill Checkpoint


### PR DESCRIPTION
Similar to PR #154 . The changes are mostly the same, but with the conflicts solved.

The changes that are not a reordering are the following:
- `429` and `457`: add unsafe paths with bash (same as Kii paths, but with less dboosts)
- `3709`: changes to dboost values in Kii, new unsafe path
- `4374`: remove a dboost
- `4459`: Added Kii paths that dboost the enemy
- `6690`: add 20 damage to dboost the 2nd balloon
- `6696`: new unsafe paths

Syntax fixes: lines `275`, `1142`, `11207`, `12453`, `12726`