### PR TITLE
New anchor WestHollow.PastRockPuzzleDoor at -322, -4276

### DIFF
--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2791,6 +2791,7 @@ anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of
       Dash, DoubleJump OR Hammer OR Spear=1
       Bash, Grenade=1, DoubleJump OR Dash OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR PauseFloat  # precise bash grenade to wall jump on the right wall. Other option to jump to the lever
       Dash, Damage=10, Glide OR Sword OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      Sword, Bash  # Precise upslash the slug above to get it down, bash it to get to the wall, sword hover to the lever - https://youtu.be/Y77mEz4gmGE
 
   pickup WestHollow.FarLeftEX:
     moki, WestHollow.FullyDrained:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2717,6 +2717,7 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
   tprestriction:
     moki: WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
     gorlek: free
+  refill Checkpoint
 
   conn WestHollow.FarLeftRoom:
     moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2678,7 +2678,7 @@ anchor WestHollow.RockPuzzle at -249, -4275:  # At the right ledge of the rock p
       WestHollow.UpperDrainLeverPulled, WaterDash, Damage=20
 
   conn WestHollow.PastRockPuzzleDoor:
-    moki: WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+    moki: WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
     unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
       Launch  # https://youtu.be/guXiDCKM18I
   conn WestHollow.HollowDrainMiddle:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2734,6 +2734,12 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
       Hammer OR Spear=1 OR GrenadeJump OR BlazeSwap=1 OR SentrySwap=1 OR FlashSwap  # Jump to the left wall and wrap around to the top
       Bow=1, PauseFloat
 
+  # backwards connection blocked by the door
+
+  # note for backwards connection: while the RockPuzzleSolved state can be initially set via header, the rock doesn't appear on top of the
+  # pressure plate until the player is far enough from it. Stepping on the pressure plate before the rock has appeared unsets the state and
+  # can create a softlock
+
 
 anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of second drain lever
   tprestriction:
@@ -2792,8 +2798,20 @@ anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of
         Sword  # Pogo the shot of the slug
         HammerSJump=1 OR AerialHammerJump OR CoyoteHammerJump OR GlideHammerJump OR GrenadeJump
 
-  # backwards connection blocked by the door
-  # note for backwards connection: while the RockPuzzleSolved state can be initially set via header, stepping on the pressure plate unsets it and can create a softlock
+    conn WestHollow.PastRockPuzzleDoor: # Keep in mind there is a path going up through the slug+skeeto and a path going down and through the horizontal gate
+      unsafe:
+        WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:  # Paths going above
+          # moki: Combat=Skeeto+Slug
+          Launch
+          Bash, Grenade=1
+          BreakCrystal, DoubleJump, TripleJump  # Break the crystal and jump off the wall. Damage=10 for lower difficulties?
+          # Sword, DoubleJump, TripleJump  # TJump and use the crystal for a reset. Redundant with BreakCrystal
+          SentryJump=1 OR GrenadeJump OR AerialHammerJump OR GroundedHammerJump OR GlideHammerJump OR FlashSwap
+        # WestHollow.FullyDrained: # Paths going through the checkpoint on -356, -4306, but requires the unmapped uberstate (937,57028)
+        #   # moki: Combat=SneezeSlug+SmallSkeeto+2xSkeeto  # SmallSkeeto explodes, not listed in EnemyIndex
+        #   Bow=3, DoubleJump
+        #   Bash  # Off the skeetos
+        #   Sword, DoubleJump
 
 # checkpoint at -356, -4306
 

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2791,7 +2791,6 @@ anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of
       Dash, DoubleJump OR Hammer OR Spear=1
       Bash, Grenade=1, DoubleJump OR Dash OR Glide OR Sword OR Hammer OR Spear=1 OR Shuriken=1 OR Blaze=1 OR Flash=1 OR Sentry=1 OR PauseFloat  # precise bash grenade to wall jump on the right wall. Other option to jump to the lever
       Dash, Damage=10, Glide OR Sword OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      Sword, Bash  # Precise upslash the slug above to get it down, bash it to get to the wall, sword hover to the lever - https://youtu.be/Y77mEz4gmGE
 
   pickup WestHollow.FarLeftEX:
     moki, WestHollow.FullyDrained:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2718,7 +2718,7 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
     gorlek: free
   refill Checkpoint
 
-  conn WestHollow.PartRockPuzzleDoorEnemyPaths:
+  conn WestHollow.PastRockPuzzleDoorEnemyPaths:
     unsafe: free  # Die to the spikes to spawn the skeeto
   conn WestHollow.FarLeftRoom:
     moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2678,8 +2678,7 @@ anchor WestHollow.RockPuzzle at -249, -4275:  # At the right ledge of the rock p
       WestHollow.UpperDrainLeverPulled, WaterDash, Damage=20
 
   conn WestHollow.PastRockPuzzleDoor:
-    moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      WestHollow.RockPuzzleSolved
+    moki: WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
     unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
       Launch  # https://youtu.be/guXiDCKM18I
   conn WestHollow.HollowDrainMiddle:
@@ -2718,6 +2717,9 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
     moki: WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
     gorlek: free
   refill Checkpoint
+
+  state WestHollow.FullyDrained:  # Watch out for redundancy with going to WestHollow.FarLeftRoom first
+    unsafe: WestHollow.UpperDrainLeverPulled, Bash  # Move the skeeto between the semisolid and the spikes - https://youtu.be/HEL2gvKB92A
 
   conn WestHollow.FarLeftRoom:
     moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
@@ -2799,20 +2801,6 @@ anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of
         Sword  # Pogo the shot of the slug
         HammerSJump=1 OR AerialHammerJump OR CoyoteHammerJump OR GlideHammerJump OR GrenadeJump
 
-    conn WestHollow.PastRockPuzzleDoor: # Keep in mind there is a path going up through the slug+skeeto and a path going down and through the horizontal gate
-      unsafe:
-        WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:  # Paths going above
-          # moki: Combat=Skeeto+Slug
-          Launch
-          Bash, Grenade=1
-          BreakCrystal, DoubleJump, TripleJump  # Break the crystal and jump off the wall. Damage=10 for lower difficulties?
-          # Sword, DoubleJump, TripleJump  # TJump and use the crystal for a reset. Redundant with BreakCrystal
-          SentryJump=1 OR GrenadeJump OR AerialHammerJump OR GroundedHammerJump OR GlideHammerJump OR FlashSwap
-        # WestHollow.FullyDrained: # Paths going through the checkpoint on -356, -4306, but requires the unmapped uberstate (937,57028)
-        #   # moki: Combat=SneezeSlug+SmallSkeeto+2xSkeeto  # SmallSkeeto explodes, not listed in EnemyIndex
-        #   Bow=3, DoubleJump
-        #   Bash  # Off the skeetos
-        #   Sword, DoubleJump
 
 # checkpoint at -356, -4306
 

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2677,7 +2677,7 @@ anchor WestHollow.RockPuzzle at -249, -4275:  # At the right ledge of the rock p
       WestHollow.UpperDrainLeverPulled, Damage=40
       WestHollow.UpperDrainLeverPulled, WaterDash, Damage=20
 
-  conn WestHollow.PastRockPuzzleDoor:
+  conn WestHollow.PastRockPuzzleDoorEnemyPaths:
     moki: WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
     unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
       Launch  # https://youtu.be/guXiDCKM18I
@@ -2712,7 +2712,39 @@ anchor WestHollow.RockPuzzle at -249, -4275:  # At the right ledge of the rock p
     unsafe:
       WestHollow.FullyDrained, Bash  # Place an enemy on HollowDrainMiddle and Bash off of it. There are multiple ways to do this, and none of them are fun. The Skeeto on the left is probably the most cooperative. This kinda looks possible from HollowDrainLower as well, but the Skeetos don't seem to have enough of an attention span to make it work.
 
-anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puzzle door
+anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puzzle door. Paths using the skeeto should use WestHollow.PastRockPuzzleDoorEnemyPaths instead
+  tprestriction:
+    moki: WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
+    gorlek: free
+  refill Checkpoint
+
+  conn WestHollow.PartRockPuzzleDoorEnemyPaths:
+    unsafe: free  # Die to the spikes to spawn the skeeto
+  conn WestHollow.FarLeftRoom:
+    moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Combat=Skeeto+Slug, Bow=1, DoubleJump OR Dash
+      Launch
+    gorlek, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Combat=Skeeto+Slug, Bow=1, Glide OR Sword
+      SentryJump=1
+      DoubleJump, Combat=Slug OR Damage=10  # Jump to the left wall and wrap around to the top
+    kii, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Bow=1, Dash OR Glide OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      DoubleJump
+    unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Hammer OR Spear=1 OR GrenadeJump OR BlazeSwap=1 OR SentrySwap=1 OR FlashSwap  # Jump to the left wall and wrap around to the top
+      Bow=1, PauseFloat
+      # Bash  # Bash off the slug when it reaches the ledge. It always spawns if you walk to the door, so it shouldn't need to be in PastRockPuzzleDoorEnemyPaths
+      # Sword  # Upslash the slug to make it fall next to you + pogo. It always spawns if you walk to the door, so it shouldn't need to be in PastRockPuzzleDoorEnemyPaths
+
+  # backwards connection blocked by the door
+
+  # note for backwards connection: while the RockPuzzleSolved state can be initially set via header, the rock doesn't appear on top of the
+  # pressure plate until the player is far enough from it. Stepping on the pressure plate before the rock has appeared unsets the state and
+  # can create a softlock
+
+anchor WestHollow.PastRockPuzzleDoorEnemyPaths at -322, -4276:  # Variant of WestHollow.PastRockPuzzleDoor that uses the Skeeto in the room
+  nospawn
   tprestriction:
     moki: WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
     gorlek: free
@@ -2721,28 +2753,12 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
   state WestHollow.FullyDrained:  # Watch out for redundancy with going to WestHollow.FarLeftRoom first
     unsafe: WestHollow.UpperDrainLeverPulled, Bash  # Move the skeeto between the semisolid and the spikes - https://youtu.be/HEL2gvKB92A
 
+  conn WestHollow.PastRockPuzzleDoor: free
   conn WestHollow.FarLeftRoom:
-    moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Combat=Skeeto+Slug, Bow=1, DoubleJump OR Dash
-      Bash OR Launch  # bashing off the skeeto
-    gorlek, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Combat=Skeeto+Slug, Bow=1, Glide OR Sword
-      SentryJump=1
-      DoubleJump, Combat=Slug OR Damage=10  # Jump to the left wall and wrap around to the top
-    kii, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Bow=1, Dash OR Glide OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      DoubleJump
-      Sword  # Pogo the skeeto
+    moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained: Bash  # The skeeto, or the slug when it reaches the ledge
+    kii, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained: Sword  # Pogo the skeeto or upslash the slug and pogo after a walljump
     unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Hammer OR Spear=1 OR GrenadeJump OR BlazeSwap=1 OR SentrySwap=1 OR FlashSwap  # Jump to the left wall and wrap around to the top
-      Bow=1, PauseFloat
-
-  # backwards connection blocked by the door
-
-  # note for backwards connection: while the RockPuzzleSolved state can be initially set via header, the rock doesn't appear on top of the
-  # pressure plate until the player is far enough from it. Stepping on the pressure plate before the rock has appeared unsets the state and
-  # can create a softlock
-
+      Grapple, UltraGrapple  # Bait the skeeto to lunge above the slug, or get lucky with the skeeto movement
 
 anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of second drain lever
   tprestriction:

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2677,22 +2677,11 @@ anchor WestHollow.RockPuzzle at -249, -4275:  # At the right ledge of the rock p
       WestHollow.UpperDrainLeverPulled, Damage=40
       WestHollow.UpperDrainLeverPulled, WaterDash, Damage=20
 
-  conn WestHollow.FarLeftRoom:
-    moki, WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Combat=Skeeto+Slug, Bow=1, DoubleJump OR Dash
-      Bash OR Launch  # bashing off the skeeto
-    gorlek, WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Combat=Skeeto+Slug, Bow=1, Glide OR Sword
-      SentryJump=1
-      DoubleJump, Combat=Slug OR Damage=10  # Jump to the left wall and wrap around to the top
-    kii, WestHollow.RockPuzzleSolved, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
-      Bow=1, Dash OR Glide OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
-      DoubleJump
-      Sword  # Pogo the skeeto
+  conn WestHollow.PastRockPuzzleDoor:
+    moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      WestHollow.RockPuzzleSolved
     unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
       Launch  # https://youtu.be/guXiDCKM18I
-      WestHollow.RockPuzzleSolved, Hammer OR Spear=1 OR GrenadeJump OR BlazeSwap=1 OR SentrySwap=1 OR FlashSwap  # Jump to the left wall and wrap around to the top
-      WestHollow.RockPuzzleSolved, Bow=1, PauseFloat
   conn WestHollow.HollowDrainMiddle:
   # If FullyDrained, this connection originates from SubmergedPlatform instead
   # WestHollow.UpperTongueExtended is a HUGE negative for this connection and you can't retract it unless you have access to SubmergedPlatform
@@ -2723,6 +2712,28 @@ anchor WestHollow.RockPuzzle at -249, -4275:  # At the right ledge of the rock p
   conn WestHollow.Entrance:
     unsafe:
       WestHollow.FullyDrained, Bash  # Place an enemy on HollowDrainMiddle and Bash off of it. There are multiple ways to do this, and none of them are fun. The Skeeto on the left is probably the most cooperative. This kinda looks possible from HollowDrainLower as well, but the Skeetos don't seem to have enough of an attention span to make it work.
+
+anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puzzle door
+  tprestriction:
+    moki: WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained
+    gorlek: free
+
+  conn WestHollow.FarLeftRoom:
+    moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Combat=Skeeto+Slug, Bow=1, DoubleJump OR Dash
+      Bash OR Launch  # bashing off the skeeto
+    gorlek, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Combat=Skeeto+Slug, Bow=1, Glide OR Sword
+      SentryJump=1
+      DoubleJump, Combat=Slug OR Damage=10  # Jump to the left wall and wrap around to the top
+    kii, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Bow=1, Dash OR Glide OR Hammer OR Spear=1 OR Shuriken=1 OR Flash=1 OR Sentry=1
+      DoubleJump
+      Sword  # Pogo the skeeto
+    unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
+      Hammer OR Spear=1 OR GrenadeJump OR BlazeSwap=1 OR SentrySwap=1 OR FlashSwap  # Jump to the left wall and wrap around to the top
+      Bow=1, PauseFloat
+
 
 anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of second drain lever
   tprestriction:
@@ -2782,6 +2793,7 @@ anchor WestHollow.FarLeftRoom at -357, -4284:  # ledge below and to the right of
         HammerSJump=1 OR AerialHammerJump OR CoyoteHammerJump OR GlideHammerJump OR GrenadeJump
 
   # backwards connection blocked by the door
+  # note for backwards connection: while the RockPuzzleSolved state can be initially set via header, stepping on the pressure plate unsets it and can create a softlock
 
 # checkpoint at -356, -4306
 

--- a/wotw_seedgen/areas.wotw
+++ b/wotw_seedgen/areas.wotw
@@ -2718,8 +2718,6 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
     gorlek: free
   refill Checkpoint
 
-  conn WestHollow.PastRockPuzzleDoorEnemyPaths:
-    unsafe: free  # Die to the spikes to spawn the skeeto
   conn WestHollow.FarLeftRoom:
     moki, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
       Combat=Skeeto+Slug, Bow=1, DoubleJump OR Dash
@@ -2734,8 +2732,8 @@ anchor WestHollow.PastRockPuzzleDoor at -322, -4276:  # Right after the rock puz
     unsafe, WestHollow.UpperDrainLeverPulled OR WestHollow.FullyDrained:
       Hammer OR Spear=1 OR GrenadeJump OR BlazeSwap=1 OR SentrySwap=1 OR FlashSwap  # Jump to the left wall and wrap around to the top
       Bow=1, PauseFloat
-      # Bash  # Bash off the slug when it reaches the ledge. It always spawns if you walk to the door, so it shouldn't need to be in PastRockPuzzleDoorEnemyPaths
-      # Sword  # Upslash the slug to make it fall next to you + pogo. It always spawns if you walk to the door, so it shouldn't need to be in PastRockPuzzleDoorEnemyPaths
+      Bash  # Bash off the slug when it reaches the ledge. It always spawns if you walk to the door, so it doesn't need to be in PastRockPuzzleDoorEnemyPaths
+      Sword  # Upslash the slug to make it fall next to you + pogo. It always spawns if you walk to the door, so it doesn't need to be in PastRockPuzzleDoorEnemyPaths
 
   # backwards connection blocked by the door
 


### PR DESCRIPTION
Added a new anchor between WestHollow.RockPuzzle and WestHollow.FarLeftRoom. It separates solving the puzzle and going into the next room from whatever happens after that.

No new paths added for existing connections. Split existing requirements to accommodate new anchor.
New paths going from WestHollow.FarLeftRoom to the new anchor.